### PR TITLE
Sort routes by name

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -106,7 +106,7 @@ angular.module('starter.controllers', ['starter.services'])
 
 .controller('RouteController', function($scope, $resource){
   $scope.routes = $resource('http://bustracker.pvta.com/infopoint/rest/routes/getvisibleroutes').query(function(){
-    $scope.routes.sort(function(a, b){return a.ShortName - b.ShortName})
+    $scope.routes.sort(function(a, b){return a.ShortName > b.ShortName ? 1 : -1})
   });
 })
 


### PR DESCRIPTION
Takes us from this routes page:

![screen shot 2016-02-11 at 12 32 10 pm](https://cloud.githubusercontent.com/assets/3988134/12984404/84d4c8ce-d0bb-11e5-8c63-7194fbd77b14.png)

to this routes page:

![screen shot 2016-02-11 at 12 32 19 pm](https://cloud.githubusercontent.com/assets/3988134/12984408/8c371a36-d0bb-11e5-9fd6-a46879e5b24f.png)

As I mentioned in #45, I think Underscore would be a nicer way to go about this, e.g.

``` js
$scope.routes = _.sortBy($scope.routes, function(route){ return route.ShortName;});
```
