### PR TITLE
Show active alerts by route

### DIFF
--- a/www/js/controllers/route-controller.js
+++ b/www/js/controllers/route-controller.js
@@ -1,12 +1,24 @@
-angular.module('pvta.controllers').controller('RouteController', function($scope, $stateParams, Route, RouteVehicles, FavoriteRoutes){
+angular.module('pvta.controllers').controller('RouteController', function($scope, $stateParams, Route, RouteVehicles, FavoriteRoutes, Messages){
   var size = 0;
   var route = Route.get({routeId: $stateParams.routeId}, function() {
     route.$save();
     getHeart();
     $scope.stops = route.Stops;
     $scope.vehicles = route.Vehicles
+
+    // Need route to be defined before we can filter messages
+    var messages = Messages.query(function(){
+      var filteredMessages = [];
+      for(var message of messages){
+        if(message.Routes.indexOf($scope.route.RouteId) === -1) { continue; }
+        filteredMessages.push(message);
+      }
+      $scope.messages = filteredMessages;
+    });
   });
   $scope.route = route;
+
+
   $scope.stops = [];
   var j = $scope.size;
   

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -35,6 +35,7 @@ angular.module('pvta.services', ['ngResource'])
 .factory('Messages', function ($resource, Avail) {
   return $resource(Avail + '/publicmessages/getcurrentmessages');
 })
+
 .factory('SimpleRoute', function ($resource, Avail){
   return $resource(Avail + '/routes/get/:routeId');
 })

--- a/www/templates/route.html
+++ b/www/templates/route.html
@@ -47,6 +47,16 @@
             </ion-item>
           </div>
        </ion-list>
+       <div class="list card" style="text-align: center;" ng-if="messages.length !== 0">
+         <h2>Active alerts for the {{route.ShortName}}:</h2>
+         <ion-list>
+           <ion-item class=item ng-repeat="item in messages">
+             <div class="row item-text-wrap">
+               {{item.Message}}
+             </div>
+           </ion-item>
+         </ion-list>
+       </div>
        <div class="list card">
         <ion-list>
         <ion-item class="item" ng-click="toggleGroup(stops)" ng-class="{active: isGroupShown(stops)}">


### PR DESCRIPTION
Closes #40.

Possible other checks we could/should add:
- checking that the alert is active on today's weekday
- checking that the alert is active at the current hour/minute
- whether it's been "published" or not
