### PR TITLE
KML Support and MapController Reorganization

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -61,6 +61,9 @@ angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment
     .state('app.vehicle', {
     url: "/vehicles/:vehicleId/:route",
     params: {
+      // For whatever reason,
+      // squash: true means that
+      // :route is an optional param
       route: {squash: true}
     },
     views: {

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -59,7 +59,10 @@ angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment
     }
   })
     .state('app.vehicle', {
-    url: "/vehicles/:vehicleId",
+    url: "/vehicles/:vehicleId/:route",
+    params: {
+      route: {squash: true}
+    },
     views: {
         'menuContent': {
           templateUrl: "templates/vehicle.html",

--- a/www/js/controllers/map-controller.js
+++ b/www/js/controllers/map-controller.js
@@ -77,6 +77,7 @@ angular.module('pvta.controllers').controller('MapController', function($scope, 
   // us to display a route.
   var shortName = KML.pop();
   if(shortName) {
+    console.log('oo');
     // If something exists, we should
     // add the route's corresponding KML
     // to the Map.

--- a/www/js/controllers/map-controller.js
+++ b/www/js/controllers/map-controller.js
@@ -77,7 +77,6 @@ angular.module('pvta.controllers').controller('MapController', function($scope, 
   // us to display a route.
   var shortName = KML.pop();
   if(shortName) {
-    console.log('oo');
     // If something exists, we should
     // add the route's corresponding KML
     // to the Map.
@@ -96,73 +95,4 @@ angular.module('pvta.controllers').controller('MapController', function($scope, 
     });
     georssLayer.setMap($scope.map);
   };
-  
-  /*
-  var bounds = new google.maps.LatLngBounds();
- var mapOptions = {
-      center: bounds.getCenter(),
-      zoom: 15,
-      mapTypeId: google.maps.MapTypeId.ROADMAP
-    };
-
-    $scope.map = new google.maps.Map(document.getElementById("map"), mapOptions);
-  
-  function setDesiredMarker(latLng){
-    var neededMarker = new google.maps.Marker({
-        map: $scope.map,
-        icon: 'http://www.google.com/mapfiles/kml/paddle/go.png',
-        animation: google.maps.Animation.DROP,
-        position: latLng
-      });
-    return neededMarker;
-  };
-  function addListener(neededMarker){
-    google.maps.event.addListener(neededMarker, 'click', function () {
-            var infoWindow = new google.maps.InfoWindow({
-              content: "Here's what you're looking for!"
-            });
-            infoWindow.open($scope.map, neededMarker);
-    });
-  };
-  
-  $cordovaGeolocation.getCurrentPosition(options).then(function(position){
-    var ll = LatLong.pop();
-    
-    if(ll !== null) {
-      var latLng = new google.maps.LatLng(ll.lat, ll.long);
-      bounds.extend(latLng);
-      addListener(setDesiredMarker(latLng));
-      
-    }
-    var myLocation = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
-   // bounds.extend(myLocation);
-     
-    
-    var georssLayer = new google.maps.KmlLayer({
-      url: 'http://bustracker.pvta.com/infopoint/Resources/Traces/route31.kml'
-    });
-    georssLayer.setMap($scope.map);
-    bounds.extend(georssLayer);
-
-    //Wait until the map is loaded
-    google.maps.event.addListenerOnce($scope.map, 'idle', function(){
-      $scope.map.fitBounds(bounds);  
-      var myMarker = new google.maps.Marker({
-        map: $scope.map,
-        animation: google.maps.Animation.DROP,
-        position: myLocation,
-        title: "You're here!"
-        });
-      google.maps.event.addListener(myMarker, 'click', function () {
-          var infoWindow = new google.maps.InfoWindow({
-            content: "You are here!"
-          });
-          infoWindow.open($scope.map, myMarker);
-      });
-      
-    });
-
-    }, function(error){
-      console.log("Could not get location");
-    });*/
 });

--- a/www/js/controllers/map-controller.js
+++ b/www/js/controllers/map-controller.js
@@ -1,35 +1,151 @@
-angular.module('pvta.controllers').controller('MapController', function($scope, $state, $resource, $stateParams, $cordovaGeolocation, Route, Vehicle, LatLong) {
+angular.module('pvta.controllers').controller('MapController', function($scope, $state, $resource, $stateParams, $cordovaGeolocation, Route, Vehicle, LatLong, KML) {
   var options = {timeout: 10000, enableHighAccuracy: true};
 
-  var ll = LatLong.pop();
-  $scope.lats = ll;
-
-  $cordovaGeolocation.getCurrentPosition(options).then(function(position){
-
-    var latLng = new google.maps.LatLng(ll.lat, ll.long);
+  //set original bounds
+  var bounds = new google.maps.LatLngBounds();
+  //set some configurable options before initializing map
+  var mapOptions = {
+    // bounds is originally the entire planet, so getCenter()
+    // will return the intersection of the Prime Meridian 
+    // and Equator by default
+    center: bounds.getCenter(),
+    zoom: 15,
+    mapTypeId: google.maps.MapTypeId.ROADMAP
+  }; 
+  //initialize map
+  $scope.map = new google.maps.Map(document.getElementById("map"), mapOptions);
+ 
+  // Assuming the user has requested something
+  // be placed on the map, grab the lat/long of that thing
+  var desiredMarkerLocation = LatLong.pop();
+  if(desiredMarkerLocation){
+    // If our assumption was correct, query the Maps API
+    // to get a valid, placeable location of our lat/long
+    var location = new google.maps.LatLng(desiredMarkerLocation.lat, desiredMarkerLocation.long);
+    // Nested call: first, place the desired marker, then
+    // add a listener for when it's tapped
+    addMapListener(placeDesiredMarker(location), "here's what you're looking for!");
+    bounds.extend(location);
+  }
+  
+  // Almost the same as immediately above.
+  // Query Cordova for current location first.
+  var currentLocation = $cordovaGeolocation.getCurrentPosition(options).then(function(position){
     var myLocation = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
-
-    var bounds = new google.maps.LatLngBounds();
-    bounds.extend(latLng);
     bounds.extend(myLocation);
-
-    var mapOptions = {
+    addMapListener(placeDesiredMarker(myLocation), 'You are here!');
+  }, function(error){});
+    
+  // Takes a google.maps.LatLng object and places a marker
+  // on the map in the requested spot.
+  // Returns a reference to said marker.
+  function placeDesiredMarker(location){
+    var neededMarker = new google.maps.Marker({
+        map: $scope.map,
+        icon: 'http://www.google.com/mapfiles/kml/paddle/go.png',
+        animation: google.maps.Animation.DROP,
+        position: location
+      });
+    return neededMarker;
+  };
+  
+  // When the map is ready, resize it to 
+  // the bounds that we have been setting each
+  // time we add something to it.
+  google.maps.event.addListenerOnce($scope.map, 'idle', function(){
+      $scope.map.fitBounds(bounds);  
+  });
+  
+  // Takes an already-created Maps marker and
+  // a string.
+  // Creates an on-tap/click listener
+  // that will display the onClickString
+  // in a little popup when the marker is
+  // tapped on.
+  // Returns nothing.
+  function addMapListener(marker, onClickString){
+    google.maps.event.addListener(marker, 'click', function () {
+            var infoWindow = new google.maps.InfoWindow({
+              content: onClickString
+            });
+            infoWindow.open($scope.map, marker);
+    });
+  }
+  
+  // Query the KML service to see 
+  // if previous controller wanted
+  // us to display a route.
+  var shortName = KML.pop();
+  if(shortName) {
+    // If something exists, we should
+    // add the route's corresponding KML
+    // to the Map.
+    addKML(shortName);
+  }
+  
+  // Takes an Avail ShortName.
+  // Uses a Maps API call to add a trace of
+  // any route (by downloading its KML file from PVTA/Avail)
+  // to the Map.
+  // Returns nothing.
+  function addKML(shortName){
+    var toAdd = 'http://bustracker.pvta.com/infopoint/Resources/Traces/route' + shortName + '.kml';
+    var georssLayer = new google.maps.KmlLayer({
+    url: toAdd
+    });
+    georssLayer.setMap($scope.map);
+  };
+  
+  /*
+  var bounds = new google.maps.LatLngBounds();
+ var mapOptions = {
       center: bounds.getCenter(),
       zoom: 15,
       mapTypeId: google.maps.MapTypeId.ROADMAP
     };
 
     $scope.map = new google.maps.Map(document.getElementById("map"), mapOptions);
-
-    //Wait until the map is loaded
-    google.maps.event.addListenerOnce($scope.map, 'idle', function(){
-      $scope.map.fitBounds(bounds);
-      var neededMarker = new google.maps.Marker({
+  
+  function setDesiredMarker(latLng){
+    var neededMarker = new google.maps.Marker({
         map: $scope.map,
         icon: 'http://www.google.com/mapfiles/kml/paddle/go.png',
         animation: google.maps.Animation.DROP,
         position: latLng
       });
+    return neededMarker;
+  };
+  function addListener(neededMarker){
+    google.maps.event.addListener(neededMarker, 'click', function () {
+            var infoWindow = new google.maps.InfoWindow({
+              content: "Here's what you're looking for!"
+            });
+            infoWindow.open($scope.map, neededMarker);
+    });
+  };
+  
+  $cordovaGeolocation.getCurrentPosition(options).then(function(position){
+    var ll = LatLong.pop();
+    
+    if(ll !== null) {
+      var latLng = new google.maps.LatLng(ll.lat, ll.long);
+      bounds.extend(latLng);
+      addListener(setDesiredMarker(latLng));
+      
+    }
+    var myLocation = new google.maps.LatLng(position.coords.latitude, position.coords.longitude);
+   // bounds.extend(myLocation);
+     
+    
+    var georssLayer = new google.maps.KmlLayer({
+      url: 'http://bustracker.pvta.com/infopoint/Resources/Traces/route31.kml'
+    });
+    georssLayer.setMap($scope.map);
+    bounds.extend(georssLayer);
+
+    //Wait until the map is loaded
+    google.maps.event.addListenerOnce($scope.map, 'idle', function(){
+      $scope.map.fitBounds(bounds);  
       var myMarker = new google.maps.Marker({
         map: $scope.map,
         animation: google.maps.Animation.DROP,
@@ -42,15 +158,10 @@ angular.module('pvta.controllers').controller('MapController', function($scope, 
           });
           infoWindow.open($scope.map, myMarker);
       });
-      google.maps.event.addListener(neededMarker, 'click', function () {
-          var infoWindow = new google.maps.InfoWindow({
-            content: "Here's what you're looking for!"
-          });
-          infoWindow.open($scope.map, neededMarker);
-      });
+      
     });
 
     }, function(error){
       console.log("Could not get location");
-    });
+    });*/
 });

--- a/www/js/controllers/route-controller.js
+++ b/www/js/controllers/route-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RouteController', function($scope, $stateParams, Route, RouteVehicles, FavoriteRoutes, Messages){
+angular.module('pvta.controllers').controller('RouteController', function($scope, $stateParams, Route, RouteVehicles, FavoriteRoutes, Messages, KML, $location){
   var size = 0;
   var route = Route.get({routeId: $stateParams.routeId}, function() {
     route.$save();
@@ -48,5 +48,10 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
     localforage.getItem(name, function(err, value){
       $scope.liked = value;
     });
+  };
+  
+  $scope.setKML = function(){
+    KML.push(route.ShortName);
+    $location.path('/app/map')
   };
 });

--- a/www/js/controllers/vehicle-controller.js
+++ b/www/js/controllers/vehicle-controller.js
@@ -1,9 +1,10 @@
 angular.module('pvta.controllers').controller('VehicleController', function($scope, $stateParams, Vehicle, LatLong, $location, KML){
   $scope.vehicle = Vehicle.get({vehicleId: $stateParams.vehicleId});
+  
   $scope.setCoordinates = function(lat, long){
     LatLong.push(lat, long);
-    //console.log($scope.vehicle.BlockFareboxId.toString().substring(0, 2));
-    KML.push($scope.vehicle.BlockFareboxId.toString().substring(0, 2));
+    console.log($stateParams.route);
+    KML.push($stateParams.route);
     $location.path('/app/map');
   }
 });

--- a/www/js/controllers/vehicle-controller.js
+++ b/www/js/controllers/vehicle-controller.js
@@ -1,7 +1,9 @@
-angular.module('pvta.controllers').controller('VehicleController', function($scope, $stateParams, Vehicle, LatLong, $location){
+angular.module('pvta.controllers').controller('VehicleController', function($scope, $stateParams, Vehicle, LatLong, $location, KML){
   $scope.vehicle = Vehicle.get({vehicleId: $stateParams.vehicleId});
   $scope.setCoordinates = function(lat, long){
     LatLong.push(lat, long);
-    $location.path('/app/map')
+    //console.log($scope.vehicle.BlockFareboxId.toString().substring(0, 2));
+    KML.push($scope.vehicle.BlockFareboxId.toString().substring(0, 2));
+    $location.path('/app/map');
   }
 });

--- a/www/js/controllers/vehicle-controller.js
+++ b/www/js/controllers/vehicle-controller.js
@@ -3,7 +3,6 @@ angular.module('pvta.controllers').controller('VehicleController', function($sco
   
   $scope.setCoordinates = function(lat, long){
     LatLong.push(lat, long);
-    console.log($stateParams.route);
     KML.push($stateParams.route);
     $location.path('/app/map');
   }

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -220,6 +220,23 @@ angular.module('pvta.services', ['ngResource'])
   };
 })
 
+.factory('KML', function(){
+  var kml = [];
+  function push(shortName){
+    kml.push(shortName);
+  };
+  function pop(){
+    if(kml.length === 1){
+      return kml.pop();
+    }
+    else return null;
+  }
+  return {
+    push: push,
+    pop: pop
+  };
+})
+
 .service('LatLong', function(){
   var latlong = [];
   return {
@@ -228,8 +245,10 @@ angular.module('pvta.services', ['ngResource'])
       latlong.push(p);
     },
     pop: function(){
-      var x = latlong.pop();
-      return x;
+      if(latlong.length === 1){
+        return latlong.pop();
+      }
+      else return null;
     }
   };
 });

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -229,7 +229,14 @@ angular.module('pvta.services', ['ngResource'])
     if(kml.length === 1){
       return kml.pop();
     }
-    else return null;
+    else{
+      // Empty the array,
+      // because anything else
+      // will produce undesired 
+      // activity in MapController
+      kml = [];
+      return null;
+    }
   }
   return {
     push: push,
@@ -248,7 +255,14 @@ angular.module('pvta.services', ['ngResource'])
       if(latlong.length === 1){
         return latlong.pop();
       }
-      else return null;
+      else {
+       // Empty the array,
+      // because anything else
+      // will produce undesired 
+      // activity in MapController
+      latlong = []; 
+      return null;
+      }
     }
   };
 });

--- a/www/templates/route.html
+++ b/www/templates/route.html
@@ -4,7 +4,7 @@
     <button id="like"  ng-class="{'button button-icon icon ion-ios-heart': liked, 'button button-icon icon ion-ios-heart-outline': !liked}" ng-click="liked= !liked; toggleHeart(liked)"></button>
   </ion-nav-buttons>  
   <ion-content>
-    <div>
+    <div class="list card">
       <div class="item-text-wrap">
         <h2 class="item" style="text-align: center; font-size: 150%">{{route.LongName}}</h2>
       </div>
@@ -75,6 +75,12 @@
       </ion-list>
        </div>
         
+      </div>
+      <div class="item tabs tabs-secondary tabs-icon-left">
+        <a class="tab-item" ng-click="setKML()">
+          <i class="icon ion-ios-location"></i>
+          Map This Route
+        </a>
       </div>
     </div>
   </ion-content>

--- a/www/templates/route.html
+++ b/www/templates/route.html
@@ -19,7 +19,7 @@
             
           </div>
           <div class="list card">
-            <ion-item class="item" ng-repeat="vehicle in vehicles" href="#/app/vehicles/{{vehicle.VehicleId}}" style="background-color: #{{route.Color}}">
+            <ion-item class="item" ng-repeat="vehicle in vehicles" href="#/app/vehicles/{{vehicle.VehicleId}}/{{route.ShortName}}" style="background-color: #{{route.Color}}">
               <div class="row" style="font-weight: bold;">
                   <div class="col" ng-if="vehicle.DisplayStatus==='Late'" style="color: red; text-align: center;">
                     Bus {{vehicle.Name}} - {{vehicle.DisplayStatus}}

--- a/www/templates/search.html
+++ b/www/templates/search.html
@@ -5,7 +5,7 @@
   <ion-content direction="y" scrollbar-y="false">
     <ion-refresher pulling-icon="ion-arrow-down-b" on-refresh="refreshItems()"></ion-refresher>
     <ion-list>
-      <ion-item collection-repeat="item in display_items" item-height= "50" href="#app/{{item.type}}s/{{item.id}}/">
+      <ion-item collection-repeat="item in display_items" item-height= "50" href="#app/{{item.type}}s/{{item.id}}">
         <p>{{item.name}}</p>
       </ion-item>
     </ion-list>

--- a/www/templates/search.html
+++ b/www/templates/search.html
@@ -5,7 +5,7 @@
   <ion-content direction="y" scrollbar-y="false">
     <ion-refresher pulling-icon="ion-arrow-down-b" on-refresh="refreshItems()"></ion-refresher>
     <ion-list>
-      <ion-item collection-repeat="item in display_items" item-height= "50" href="#app/{{item.type}}s/{{item.id}}">
+      <ion-item collection-repeat="item in display_items" item-height= "50" href="#app/{{item.type}}s/{{item.id}}/">
         <p>{{item.name}}</p>
       </ion-item>
     </ion-list>


### PR DESCRIPTION
Closes #36.  Adds support for adding an overlay to the Map view that traces any of PVTA's routes (the  file containing the coordinate list has extension `.kml`, hence why we use the term).  

When asking for the location of a vehicle through a specific route's page, the KML is displayed on the map.  Also, each Route page has a button on the bottom for plotting the route.

When asking for the location of a vehicle through Search, a KML is NOT displayed.

The support for picking the correct KML comes from a new optional parameter to the **vehicle** state, which takes an Avail ShortName (30, 35, B43, R29, etc), which is needed to query Infopoint for the proper file.  We can't easily get this info through a vehicle that has been selected from Search, because a single vehicle's data from Avail includes a unit (30-3, 43-1, etc), but not the ShortName.  For all operators other than UMTS,  **unit** and **short name** are different entities, so passing the unit doesn't get us the correct KML for Vatco and Satco buses.

This PR also includes a completely revitalized MapController that is hopefully modular enough to support extensions in the future.  I see that @petermarathas is working on #32, so I hope that this won't conflict with his work.
