### PR TITLE
Settings and About Pages

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="com.ionicframework.conference849931" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.umts.pvta-multiplaform" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>PVTA</name>
   <description>
         The best way to find your buses on the go.
     </description>
   <author email="akaplowitz@umass.edu" href="http://example.com.com/">
-      Aaron Kaplowitz
+      Aaron Kaplowitz for UMass Transit
     </author>
   <content src="index.html"/>
   <access origin="*"/>
+  <access origin="mailto:*" launch-external="yes" />
   <preference name="webviewbounce" value="false"/>
   <preference name="UIWebViewBounce" value="false"/>
   <preference name="DisallowOverscroll" value="true"/>

--- a/config.xml
+++ b/config.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="com.umts.pvta-multiplaform" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.umts.pvta-multiplaform" version="0.5.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>PVTA</name>
   <description>
         The best way to find your buses on the go.
     </description>
-  <author email="akaplowitz@umass.edu" href="http://example.com.com/">
-      Aaron Kaplowitz for UMass Transit
+  <author email="transit-it@umass.edu" href="http://umass.edu/bus">
+      UMass Transit
     </author>
   <content src="index.html"/>
   <access origin="*"/>

--- a/www/index.html
+++ b/www/index.html
@@ -44,6 +44,8 @@
     <script src="js/controllers/stops-controller.js"></script>
     <script src="js/controllers/map-controller.js"></script>
     <script src="js/controllers/my-buses-controller.js"></script>
+    <script src="js/controllers/settings-controller.js"></script>
+    <script src="js/controllers/about-controller.js"></script>
     
 
 

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -107,6 +107,26 @@ angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment
       }
     }
   })
+  
+  .state('app.settings', {
+    url: "/settings",
+    views: {
+      'menuContent': {
+        templateUrl: "templates/settings.html",
+        controller: 'SettingsController'
+      }
+    }
+  })
+  
+   .state('app.about', {
+    url: "/about",
+    views: {
+      'menuContent': {
+        templateUrl: "templates/about.html",
+        controller: 'AboutController'
+      }
+    }
+  })
 
   .state('app.map', {
     url: "/map",

--- a/www/js/controllers/about-controller.js
+++ b/www/js/controllers/about-controller.js
@@ -1,0 +1,4 @@
+angular.module('pvta.controllers').controller('AboutController', function($scope, Info){
+  $scope.vNum = Info.versionNum;
+  $scope.vName = Info.versionName;
+});

--- a/www/js/controllers/settings-controller.js
+++ b/www/js/controllers/settings-controller.js
@@ -1,0 +1,3 @@
+angular.module('pvta.controllers').controller('SettingsController', function($scope){
+  
+});

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -46,8 +46,8 @@ angular.module('pvta.services', ['ngResource'])
 
 .factory('Info', function(){
   return {
-    versionNum: '0.0.1',
-    versionName: 'Beta 1'
+    versionNum: '0.5.0',
+    versionName: 'Beta 2'
   };
 })
 

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -44,6 +44,12 @@ angular.module('pvta.services', ['ngResource'])
   return $resource(Avail + '/routes/get/:routeId');
 })
 
+.factory('Info', function(){
+  return {
+    versionNum: '0.0.1',
+    versionName: 'Beta 1'
+  };
+})
 
 
 

--- a/www/templates/about.html
+++ b/www/templates/about.html
@@ -1,12 +1,18 @@
 <ion-view view-title="About">
   <ion-content>
-    <div class="list card">
+    <div class="list card item-text-wrap">
       <div class="item item-icon-center">
         Version: {{vNum}}, {{vName}}
       </div>
       <div class="item">
-        Made with <i class="icon ion-ios-heart"></i> by UMass Transit IT
+        Made with <i class="icon ion-ios-heart"></i> by UMass Transit's student developers in Amherst, MA
       </div>
+      <a href="http://github.com/umts/pvta-multiplatform" class="item item-icon-left">
+        Contribute to pvta-multiplatform<i class="icon ion-social-github"></i>
+      </a>
+      <a class="item" href="mailto:transit-it@admin.umass.edu" target="_blank">
+        Find a bug?  Let us know!
+      </a>
     </div>
   </ion-content>
 </ion-view>

--- a/www/templates/about.html
+++ b/www/templates/about.html
@@ -1,0 +1,12 @@
+<ion-view view-title="About">
+  <ion-content>
+    <div class="list card">
+      <div class="item item-icon-center">
+        Version: {{vNum}}, {{vName}}
+      </div>
+      <div class="item">
+        Made with <i class="icon ion-ios-heart"></i> by UMass Transit IT
+      </div>
+    </div>
+  </ion-content>
+</ion-view>

--- a/www/templates/about.html
+++ b/www/templates/about.html
@@ -5,12 +5,16 @@
         Version: {{vNum}}, {{vName}}
       </div>
       <div class="item">
-        Made with <i class="icon ion-ios-heart"></i> by UMass Transit's student developers in Amherst, MA
+        Made with <a class="icon ion-ionic" href="http://ionicframework.com"></a>,
+        <a class="ion-social-angular" href="https://angularjs.org"></a>,
+        and <a class="ion-ios-heart" href="https://en.wikipedia.org/wiki/Love"></a>
+        by UMass Transit's student developers in Amherst, MA
       </div>
       <a href="http://github.com/umts/pvta-multiplatform" class="item item-icon-left">
         Contribute to pvta-multiplatform<i class="icon ion-social-github"></i>
       </a>
-      <a class="item" href="mailto:transit-it@admin.umass.edu" target="_blank">
+      <a class="item item-icon-left" href="mailto:transit-it@admin.umass.edu" target="_blank">
+        <i class="icon ion-bug"></i>
         Find a bug?  Let us know!
       </a>
     </div>

--- a/www/templates/menu.html
+++ b/www/templates/menu.html
@@ -34,6 +34,10 @@
           <i class="icon ion-ios-location" style="margin-right: 10px"></i>
           Stops
         </ion-item>
+        <ion-item menu-close href="#/app/settings">
+          <i class="icon ion-ios-gear" style="margin-right: 10px"></i>
+          Settings
+        </ion-item>
       </ion-list>
     </ion-content>
   </ion-side-menu>

--- a/www/templates/route.html
+++ b/www/templates/route.html
@@ -16,9 +16,8 @@
               None
               <i class="icon ion-thumbsdown"></i>
             </div>
-            
           </div>
-          <div class="list card">
+          <div class="list card" ng-if="vehicles.length > 0">
             <ion-item class="item" ng-repeat="vehicle in vehicles" href="#/app/vehicles/{{vehicle.VehicleId}}" style="background-color: #{{route.Color}}">
               <div class="row" style="font-weight: bold;">
                   <div class="col" ng-if="vehicle.DisplayStatus==='Late'" style="color: red; text-align: center;">

--- a/www/templates/settings.html
+++ b/www/templates/settings.html
@@ -1,0 +1,9 @@
+<ion-view view-title="Settings">
+  <ion-content>
+    <ion-list>
+      <ion-item href="#/app/about">
+        About
+      </ion-item>
+    </ion-list>
+  </ion-content>
+</ion-view>

--- a/www/templates/settings.html
+++ b/www/templates/settings.html
@@ -4,6 +4,24 @@
       <ion-item href="#/app/about">
         About
       </ion-item>
+        <li class="item item-toggle">
+          Data Saver
+          <label class="toggle">
+           <input type="checkbox">
+            <div class="track">
+              <div class="handle"></div>
+            </div>
+          </label>
+        </li>
+        <li class="item item-toggle">
+          Use location to find nearest stops
+          <label class="toggle">
+           <input type="checkbox">
+            <div class="track">
+              <div class="handle"></div>
+            </div>
+          </label>
+        </li>
     </ion-list>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
Closes #30. This PR includes barebones settings/about pages.  If anyone has any ideas about the style of these pages or anything that should be added, let me know and I'll add them before merging.

Settings: (those toggles don't currently do anything)
<img width="500" alt="screen shot 2016-02-25 at 11 42 48 pm" src="https://cloud.githubusercontent.com/assets/7144148/13343319/86dd1efa-dc19-11e5-9b33-61a367939ba2.png">

About:
<img width="504" alt="screen shot 2016-02-25 at 11 42 56 pm" src="https://cloud.githubusercontent.com/assets/7144148/13343324/90c4512c-dc19-11e5-8686-b34cee9fb642.png">
