### PR TITLE
Fix Stops List (and Routes List)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -9,7 +9,7 @@
     </author>
   <content src="index.html"/>
   <access origin="*"/>
-  <access origin="mailto:*" launch-external="yes" />
+  <access origin="mailto:*" launch-external="yes"/>
   <preference name="webviewbounce" value="false"/>
   <preference name="UIWebViewBounce" value="false"/>
   <preference name="DisallowOverscroll" value="true"/>

--- a/www/js/controllers/routes-controller.js
+++ b/www/js/controllers/routes-controller.js
@@ -6,6 +6,7 @@ angular.module('pvta.controllers').controller('RoutesController', function ($sco
   RouteForage.get().then(function(routes){
     RouteForage.save(routes);
     $scope.routes = stripDetails(routes);
+    $scope.$apply();
   });
   
   function stripDetails(routeList){

--- a/www/js/controllers/search-controller.js
+++ b/www/js/controllers/search-controller.js
@@ -23,12 +23,10 @@ angular.module('pvta.controllers').controller('SearchController', function($scop
       }
       return routes;
     }
-    
     RouteForage.get().then(function(routes){
       RouteForage.save(routes);
       prepareRoutes(routes);
     });
-  
     $cordovaGeolocation.getCurrentPosition().then(function (position) {
       StopsForage.get(position.coords.latitude, position.coords.longitude).then(function(stops){
         StopsForage.save(stops);

--- a/www/js/controllers/stops-controller.js
+++ b/www/js/controllers/stops-controller.js
@@ -1,9 +1,9 @@
 angular.module('pvta.controllers').controller('StopsController', function ($scope, $resource, Stops, NearestStops, $ionicFilterBar, $cordovaGeolocation, StopsForage) {
-  $scope.display_message = 'No results found.';
   var filterBarInstance;
   $cordovaGeolocation.getCurrentPosition().then(function (position) {
     StopsForage.get(position.coords.latitude, position.coords.longitude).then(function(stops){
       $scope.stops = stops;
+      $scope.$apply();
       StopsForage.save(stops);
     });
   });

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -329,7 +329,7 @@ angular.module('pvta.services', ['ngResource'])
   function getRouteList(){
     if(RouteList.isEmpty()){
       return localforage.getItem('routes').then(function(routes){
-        if(routes && (Recent.recent(routes.time))){
+        if((routes != null) && (routes.length > 0) && (Recent.recent(routes.time))){
           return routes.list;
         }
         else {
@@ -362,7 +362,7 @@ angular.module('pvta.services', ['ngResource'])
   function getStopList(lat, long){
     if(StopList.isEmpty()){
       return localforage.getItem('stops').then(function(stops){
-        if(stops && (Recent.recent(stops.time))){
+        if((stops != null) && (stops.length > 0) && (Recent.recent(stops.time))){
           return stops.list;
         }
         else {

--- a/www/templates/stops.html
+++ b/www/templates/stops.html
@@ -10,7 +10,7 @@
       </ion-item>
     </ion-list>
     <div ng-if="stops.length == 0">
-      <center ng-bind-html="displayMessage"></center>
+      <center>No results</center>
     </div>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
Closes #102.  Resolves an issue that was caused by a combination of a few things in the RoutesForage and StopsForage services.

These issues were:
- Checking that an array exists would return true, but said array would be empty and we'd be left without a route/stop list
- Once the correct list was finally returned to the calling function, the $scope variable it was assigned to kinda fell through the cracks.  We call `$scope.$apply()` to fix this and force a redraw.
