### PR TITLE
Routes With Multiple Directions Making Stops

### DIFF
--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -39,7 +39,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         // keep track of ROUTES vs DIRECTIONS
         routes = _.uniq(_.pluck(directions, 'RouteId'));
         // Now, loop through each RouteId
-        /*_.each(routes, function (id, index) {
+        _.each(routes, function (id, index) {
           // Pull out the departures that match the RouteId
           // of our current iteration:
           var departuresForRoute = _.map(directions, function (routeDirection) {
@@ -85,11 +85,11 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
           }
           // Otherwise, remove its ID from the routes array so that it's dealt with no further.
           else {
-            routes.slice(index, 1);
+            routes.splice(index, 1);
           }
         });
-      */
 
+/*
       _.each(routes, function(routeId){
         var routeObject = {RouteId: routeId, Departures: []};
         $scope.departuresByRoute.push(routeObject);
@@ -113,7 +113,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         }
       });
       console.log(JSON.stringify(newDeps));
-
+*/
         // The very last thing we need to do is download
         // some details (name, color, etc) for each route that has
         // upcoming departures at this stop.

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -72,17 +72,19 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
          */
         var routeDepartures = []
         _.each(routes, function(route) {
+          //[{RouteId: 20034, Departures[...]},]
           var entireObject = _.where(dirs, {RouteId : route});
+          // [[...], [...]]
           var justDepartures = _.pluck(entireObject, 'Departures');
+          // [, , , ]
           var flattenedDepartures = _.flatten(justDepartures, true);
           if (flattenedDepartures && flattenedDepartures.length > 0) {
             var newDir = {RouteId: route, Departures: flattenedDepartures};
             routeDepartures.push(newDir);
           }
         });
-        console.log(JSON.stringify(routeDepartures));
         /* Step 3:
-         * We now have an array of {RoudId, Departure}
+         * We now have an array of {RouteId, Departure}
          * objects. We now get "stringified" times for each departure.
          * We define a new object ($scope.departuresByRoute) to hold
          * our final data.
@@ -100,22 +102,24 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         _.each(routeDepartures, function(routeAndDepartures) {
           var newDirsWithTimes = {RouteId: routeAndDepartures.RouteId, Departures: []}
           _.each(routeAndDepartures.Departures, function(departure) {
-           if (moment(departure.EDT).fromNow().includes('ago')) return;
+           if (!moment(departure.EDT).isAfter(Date.now())) return;
             else {
               var times = {s: moment(departure.SDT).fromNow(), e: moment(departure.EDT).fromNow()};
               departure.Times = times;
               newDirsWithTimes.Departures.push(departure);
             }
           });
-          $scope.departuresByRoute.push(newDirsWithTimes);
-        })
+          if (newDirsWithTimes.Departures.length > 0) {
+              $scope.departuresByRoute.push(newDirsWithTimes);
+          }
+        });
 
 
         /* Step 4:
          * Download some details (name, color, etc) for each
          * route that has upcoming departures at this stop.
          */
-        getRoutes(routes);
+        getRoutes(_.pluck($scope.departuresByRoute, 'RouteId'));
       } // end highest if
     });
   }; // end getDepartures

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -63,11 +63,16 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
               departuresForRoute[indexInList] = departure;
             }
           });
+          // Remove any null values created by departures in the past.
+          departuresForRoute = _.compact(departuresForRoute);
           // This is the last thing we do for each route:
           // push it (as an object) to the array that will be used in the view.
           $scope.departuresByRoute.push({RouteId: id, Departures: departuresForRoute});
         });
-        getRoutes($scope.directions);
+        // The very last thing we need to do is download
+        // route details for each route that has
+        // upcoming departures at this stop.
+        getRoutes(routes);
       } // end highest if
     });
   }; // end getDepartures

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -57,11 +57,18 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         /* Step 2:
          * For each RouteId, find all the departures
          * (obtained in Step 1) whose RouteDirection matches this Id.
-         * This obtains an array of Departure arrays, so "flatten"
-         * it down to a single array.
+         * This obtains an array of Departure arrays
+         *    (this root array has one element when
+         *       there's only 1 RouteDirection for a RouteId, but has
+         *       n elements for each RouteId that has n RouteDirections
+         *    ), so "flatten" it down to a single array.
          * Assuming this array of departures exists and
          * actually HAS departures, we have now
          * found every known departure for this route.
+         *
+         * The routeDepartures variable will contain
+         * an array of routes and their corresponding
+         * departures in form [{RouteId, Departures}, ...]
          */
         var routeDepartures = []
         _.each(routes, function(route) {

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -39,7 +39,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         // keep track of ROUTES vs DIRECTIONS
         routes = _.uniq(_.pluck(directions, 'RouteId'));
         // Now, loop through each RouteId
-        _.each(routes, function (id) {
+        /*_.each(routes, function (id, index) {
           // Pull out the departures that match the RouteId
           // of our current iteration:
           var departuresForRoute = _.map(directions, function (routeDirection) {
@@ -78,9 +78,42 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
           // Remove any null values created by departures in the past.
           departuresForRoute = _.compact(departuresForRoute);
           // This is the last thing we do for each route:
+          // Assuming that is has departures (which we finally know for certain)
           // push it (as an object) to the array that will be used in the view.
-          $scope.departuresByRoute.push({RouteId: id, Departures: departuresForRoute});
+          if (departuresForRoute.length > 1) {
+              $scope.departuresByRoute.push({RouteId: id, Departures: departuresForRoute});
+          }
+          // Otherwise, remove its ID from the routes array so that it's dealt with no further.
+          else {
+            routes.slice(index, 1);
+          }
         });
+      */
+
+      _.each(routes, function(routeId){
+        var routeObject = {RouteId: routeId, Departures: []};
+        $scope.departuresByRoute.push(routeObject);
+      });
+      var newDeps = $scope.departuresByRoute;
+      _.each(directions, function(routeDirection) {
+        if (!routeDirection.IsDone && routeDirection.Departures.length > 0) {
+          for (var i = 0; i < newDeps.length; i++) {
+            if (newDeps[i].RouteId === routeDirection.RouteId) {
+              newDeps[i].Departures = newDeps[i].Departures.concat(routeDirection.Departures);
+            }
+          }
+        }
+      });
+      console.log(JSON.stringify(newDeps));
+      _.each(newDeps, function(routeObject, index) {
+        console.log(JSON.stringify(routeObject.RouteId));
+        console.log(JSON.stringify(routeObject.Departures));
+        if (!routeObject.Departures || routeObject.Departures.length < 1) {
+          newDeps = newDeps.splice(index, 1);
+        }
+      });
+      console.log(JSON.stringify(newDeps));
+
         // The very last thing we need to do is download
         // some details (name, color, etc) for each route that has
         // upcoming departures at this stop.

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -39,12 +39,12 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         // keep track of ROUTES vs DIRECTIONS
         routes = _.uniq(_.pluck(directions, 'RouteId'));
         // Now, loop through each RouteId
-        _.each(routes, function(id){
+        _.each(routes, function (id) {
           // Pull out the departures that match the RouteId
           // of our current iteration:
-          var departuresForRoute = _.map(directions, function(routeDirection){
+          var departuresForRoute = _.map(directions, function (routeDirection) {
             // Make sure that the departures array exists / isn't empty
-            // (basically is a truthy), and that this direction
+            // (basically is a truthy. != as opposed to !== IS ON PURPOSE.), and that this direction
             // isn't done servicing this stop for the day.
             if (routeDirection.Departures.length != 0 && !routeDirection.IsDone) {
               // Finally, return the departures that
@@ -63,7 +63,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
           // Before we add it to the master list for the entire stop,
           // we define an extra property **to each departure** to make the times
           // easily readable.
-          _.each(departuresForRoute, function(departure, indexInList){
+          _.each(departuresForRoute, function (departure, indexInList) {
             // If the departure was in the past, toss it.
             if (moment(departure.EDT).fromNow().includes('ago')) departuresForRoute[indexInList] = null;
             else {

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -26,16 +26,32 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         _.each(directions, function (direction) {
           if (direction.Departures.length !== 0 && !direction.IsDone) {
             var dir = {RouteId: direction.RouteId, departures: []};
-            routes.push(direction.RouteId);
-            _.each(direction.Departures, function (departure) {
-              if (moment(departure.EDT).fromNow().includes('ago')) return;
-              else {
-                var times = {s: moment(departure.SDT).fromNow(), e: moment(departure.EDT).fromNow()};
-                departure.Times = times;
-                dir.departures.push(departure);
-              }
-            });
-            $scope.directions.push(dir);
+            if (!(_.contains(routes, direction.RouteId))) {
+              routes.push(direction.RouteId);
+              _.each(direction.Departures, function (departure) {
+                if (moment(departure.EDT).fromNow().includes('ago')) return;
+                else {
+                  var times = {s: moment(departure.SDT).fromNow(), e: moment(departure.EDT).fromNow()};
+                  departure.Times = times;
+                  dir.departures.push(departure);
+                }
+              });
+              $scope.directions.push(dir);
+            }
+            else {
+              _.each(direction.Departures, function(departure) {
+                if (moment(departure.EDT).fromNow().includes('ago')) return;
+                else {
+                  var times = {s: moment(departure.SDT).fromNow(), e: moment(departure.EDT).fromNow()};
+                  departure.Times = times;
+                  dir.departures.push(departure);
+                }
+              });
+              var alreadyExistingDirection = _.findWhere($scope.directions, {RouteId: direction.RouteId});
+              var index = _.indexOf($scope.directions, alreadyExistingDirection);
+              alreadyExistingDirection.departures.push(dir);
+              $scope.directions[index] = alreadyExistingDirection;
+            }
           }
         }); // end underscore.each
         getRoutes($scope.directions);

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -63,17 +63,17 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
          * actually HAS departures, we have now
          * found every known departure for this route.
          */
-        var closer = []
+        var routeDepartures = []
         _.each(routes, function(route) {
-          var x = _.where(dirs, {RouteId : route});
-          var y = _.pluck(x, 'Departures');
-          var z = _.flatten(y, true);
-          if (z && z.length > 0) {
-            var newDir = {RouteId: route, Departures: z};
-            closer.push(newDir);
+          var entireObject = _.where(dirs, {RouteId : route});
+          var justDepartures = _.pluck(entireObject, 'Departures');
+          var flattenedDepartures = _.flatten(justDepartures, true);
+          if (flattenedDepartures && flattenedDepartures.length > 0) {
+            var newDir = {RouteId: route, Departures: flattenedDepartures};
+            routeDepartures.push(newDir);
           }
         });
-        console.log(JSON.stringify(closer));
+        console.log(JSON.stringify(routeDepartures));
         /* Step 3:
          * We now have an array of {RoudId, Departure}
          * objects. We now get "stringified" times for each departure.
@@ -90,7 +90,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
          * everything for that route to the final array.
          */
         $scope.departuresByRoute = [];
-        _.each(closer, function(routeAndDepartures) {
+        _.each(routeDepartures, function(routeAndDepartures) {
           var newDirsWithTimes = {RouteId: routeAndDepartures.RouteId, Departures: []}
           _.each(routeAndDepartures.Departures, function(departure) {
            if (moment(departure.EDT).fromNow().includes('ago')) return;

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -50,12 +50,13 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         _.each(routes, function(route) {
           var x = _.where(dirs, {RouteId : route});
           var y = _.pluck(x, 'Departures');
-          console.log(JSON.stringify(y));
           var z = _.flatten(y, true);
-          console.log(JSON.stringify(z));
-          var newDir = {RouteId: route, Departures: z};
-          closer.push(newDir);
+          if (z && z.length > 0) {
+            var newDir = {RouteId: route, Departures: z};
+            closer.push(newDir);
+          }
         });
+        console.log(JSON.stringify(closer));
         $scope.departuresByRoute = [];
         _.each(closer, function(routeAndDepartures) {
           var newDirsWithTimes = {RouteId: routeAndDepartures.RouteId, Departures: []}

--- a/www/js/controllers/stop-controller.js
+++ b/www/js/controllers/stop-controller.js
@@ -6,8 +6,8 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
   };
 
   var getRoutes = function (routes) {
-    _.each(routes, function (route) {
-      $scope.getRoute(route.RouteId);
+    _.each(routes, function (routeId) {
+      $scope.getRoute(routeId);
     });
   };
 
@@ -31,10 +31,10 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
           // Pull out the departures that match the RouteId
           // of our current iteration:
           var departuresForRoute = _.map(directions, function(routeDirection){
-            // Make sure that the departures array isn't empty
-            // and that this direction isn't done
-            // servicing this stop for the day
-            if (routeDirection.Departures.length !== 0 && !routeDirection.IsDone) {
+            // Make sure that the departures array exists / isn't empty
+            // (basically is a truthy), and that this direction
+            // isn't done servicing this stop for the day.
+            if (routeDirection.Departures.length != 0 && !routeDirection.IsDone) {
               // Finally, return the departures that
               // match this RouteId
               if (routeDirection.RouteId === id) {

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -6,7 +6,7 @@
   <ion-content direction="y" scrollbar-y="false">
     <ion-refresher pulling-text="Pull to refresh..." on-refresh="refresh()"></ion-refresher>
     <!-- For every route, group it and allow it to be toggled open or closed -->
-    <ion-list ng-repeat="routeDepartures in thenewone">
+    <ion-list ng-repeat="routeDepartures in departuresByRoute">
       <ion-item class="item-text-wrap" ng-click="toggleGroup({{routeDepartures.RouteId}})" ng-class="{active: isGroupShown({{routeDepartures.RouteId}})}">
         <div class="row">
           <span class="col" style="font-weight: bold;font-size: 175%; color: #{{routeList[routeDepartures.RouteId].Color}};">

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -5,8 +5,9 @@
   </ion-nav-buttons>
   <ion-content direction="y" scrollbar-y="false">
     <ion-refresher pulling-text="Pull to refresh..." on-refresh="refresh()"></ion-refresher>
-    <!-- For every route, group it and allow it to be toggled open or closed -->  
-    <ion-list ng-repeat="direction in directions">  
+    <!-- For every route, group it and allow it to be toggled open or closed -->
+    <ion-list ng-repeat="direction in directions">
+      {{direction}}
       <ion-item class="item-text-wrap" ng-click="toggleGroup({{direction.RouteId}})" ng-class="{active: isGroupShown({{direction.RouteId}})}">
         <div class="row">
           <span class="col" style="font-weight: bold;font-size: 175%; color: #{{routeList[direction.RouteId].Color}};">
@@ -18,7 +19,7 @@
           </span>
         </div>
       </ion-item>
-      <!-- When a route has been expanded, show its departures -->        
+      <!-- When a route has been expanded, show its departures -->
       <ion-item class="item-accordion"
                       ng-repeat="departure in direction.departures"
                       ng-show="isGroupShown({{direction.RouteId}})" href="#/app/routes/{{direction.RouteId}}">
@@ -34,15 +35,15 @@
           </span>
         </div>
       </ion-item>
-    </ion-list> 
+    </ion-list>
     <div ng-if="!directions.length">
       <ion-item class="item item-assertive" style="text-align:center">{{stop.Name}} has no departures for at least the next 3 hours.</ion-item>
-    </div> 
+    </div>
   </ion-content>
   <ion-footer-bar class="bar-positive">
     <a class="button col-offset-50" ng-click="setCoordinates(stop.Latitude, stop.Longitude)">
       Find on map
-    <i class="icon ion-ios-location"></i> 
+    <i class="icon ion-ios-location"></i>
     </a>
-  </ion-footer-bar> 
+  </ion-footer-bar>
 </ion-view>

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -7,7 +7,6 @@
     <ion-refresher pulling-text="Pull to refresh..." on-refresh="refresh()"></ion-refresher>
     <!-- For every route, group it and allow it to be toggled open or closed -->
     <ion-list ng-repeat="routeDepartures in departuresByRoute">
-      {{routeDepartures}}
       <ion-item class="item-text-wrap" ng-click="toggleGroup({{routeDepartures.RouteId}})" ng-class="{active: isGroupShown({{routeDepartures.RouteId}})}">
         <div class="row">
           <span class="col" style="font-weight: bold;font-size: 175%; color: #{{routeList[routeDepartures.RouteId].Color}};">
@@ -36,7 +35,7 @@
         </div>
       </ion-item>
     </ion-list>
-    <div ng-if="!directions.length">
+    <div ng-if="!departuresByRoute.length">
       <ion-item class="item item-assertive" style="text-align:center">{{stop.Name}} has no departures for at least the next 3 hours.</ion-item>
     </div>
   </ion-content>

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -6,23 +6,23 @@
   <ion-content direction="y" scrollbar-y="false">
     <ion-refresher pulling-text="Pull to refresh..." on-refresh="refresh()"></ion-refresher>
     <!-- For every route, group it and allow it to be toggled open or closed -->
-    <ion-list ng-repeat="direction in directions">
-      {{direction}}
-      <ion-item class="item-text-wrap" ng-click="toggleGroup({{direction.RouteId}})" ng-class="{active: isGroupShown({{direction.RouteId}})}">
+    <ion-list ng-repeat="routeDepartures in departuresByRoute">
+      {{routeDepartures}}
+      <ion-item class="item-text-wrap" ng-click="toggleGroup({{routeDepartures.RouteId}})" ng-class="{active: isGroupShown({{routeDepartures.RouteId}})}">
         <div class="row">
-          <span class="col" style="font-weight: bold;font-size: 175%; color: #{{routeList[direction.RouteId].Color}};">
-            {{routeList[direction.RouteId].ShortName}}
+          <span class="col" style="font-weight: bold;font-size: 175%; color: #{{routeList[routeDepartures.RouteId].Color}};">
+            {{routeList[routeDepartures.RouteId].ShortName}}
           </span>
-          <span class="col">View upcoming departures for the {{routeList[direction.RouteId].ShortName}}</span>
+          <span class="col">View upcoming departures for the {{routeList[routeDepartures.RouteId].ShortName}}</span>
           <span class="col">
-            <i class="icon" ng-class="isGroupShown({{direction.RouteId}}) ? 'ion-ios-arrow-down' : 'ion-ios-arrow-up'" style="margin-right: 10px;"></i>
+            <i class="icon" ng-class="isGroupShown({{routeDepartures.RouteId}}) ? 'ion-ios-arrow-down' : 'ion-ios-arrow-up'" style="margin-right: 10px;"></i>
           </span>
         </div>
       </ion-item>
       <!-- When a route has been expanded, show its departures -->
       <ion-item class="item-accordion"
-                      ng-repeat="departure in direction.departures"
-                      ng-show="isGroupShown({{direction.RouteId}})" href="#/app/routes/{{direction.RouteId}}">
+                      ng-repeat="departure in routeDepartures.Departures"
+                      ng-show="isGroupShown({{routeDepartures.RouteId}})" href="#/app/routes/{{routeDepartures.RouteId}}">
         <div class="row">
           <span class="col" style="font-weight:bold;">
             {{departure.Trip.InternetServiceDesc}}

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -35,7 +35,7 @@
         </div>
       </ion-item>
     </ion-list>
-    <div ng-if="!departuresByRoute.length">
+    <div ng-if="!newMasterList.length">
       <ion-item class="item item-assertive" style="text-align:center">{{stop.Name}} has no departures for at least the next 3 hours.</ion-item>
     </div>
   </ion-content>

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -6,7 +6,7 @@
   <ion-content direction="y" scrollbar-y="false">
     <ion-refresher pulling-text="Pull to refresh..." on-refresh="refresh()"></ion-refresher>
     <!-- For every route, group it and allow it to be toggled open or closed -->
-    <ion-list ng-repeat="routeDepartures in departuresByRoute">
+    <ion-list ng-repeat="routeDepartures in thenewone">
       <ion-item class="item-text-wrap" ng-click="toggleGroup({{routeDepartures.RouteId}})" ng-class="{active: isGroupShown({{routeDepartures.RouteId}})}">
         <div class="row">
           <span class="col" style="font-weight: bold;font-size: 175%; color: #{{routeList[routeDepartures.RouteId].Color}};">

--- a/www/templates/stop.html
+++ b/www/templates/stop.html
@@ -35,7 +35,7 @@
         </div>
       </ion-item>
     </ion-list>
-    <div ng-if="!newMasterList.length">
+    <div ng-if="!departuresByRoute.length">
       <ion-item class="item item-assertive" style="text-align:center">{{stop.Name}} has no departures for at least the next 3 hours.</ion-item>
     </div>
   </ion-content>


### PR DESCRIPTION
Closes #108.

Introduces no changes to the user experience, but, again, extensively reworks the StopDeparture parsing logic.

Now, having multiple directions (ie OHill and Mullins) for a single route at one stop does not cause two entries for the route in the UI.

This PR proposes logic that:
-  Goes through the data and pulls out the unique routes that have upcoming departures
- Based on the routes from above, creates an array of departures that is organized by ROUTE and can be parsed by direction if needed (which is done in the view, but not in code).

@petermarathas and @bgregg I'd really like you guys to take a look at this before it gets merged, because it kinda needs to work and I may have missed something again.

I've also extensively commented Stop.js, so all my changes should be pretty obvious to understand now.
