### PR TITLE
Fix Stop Redirection

### DIFF
--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -34,7 +34,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       StopsForage.get(position.coords.latitude, position.coords.longitude).then(function (stops) {
         StopsForage.save(stops);
         stops = StopsForage.uniq(stops);
-        prepareStops(stops);
+        $scope.stops = prepareStops(stops);
       });
     }, function (err) {
       // If location services fail us, just
@@ -43,21 +43,17 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       StopsForage.get().then(function (stops) {
         stops = StopsForage.uniq(stops);
         StopsForage.save(stops);
-        prepareStops(stops);
+        $scope.stops = prepareStops(stops);
       });
     });
-    $scope.stops = [];
     /* Similar to prepareRoutes, we only
      * keep the details about each stop that are useful
      * to us for displaying them.  It makes searching easier.
      */
     function prepareStops (list) {
-      for (var i = 0; i < list.length; i++) {
-        $scope.stops.push({name: list[i].Name,
-                        type: 'stop',
-                        id: list[i].StopId
-                        });
-      }
+      return _.map(list, function (stop) {
+        return _.pick(stop, 'StopId', 'Name');
+      });
     }
   }
   // Two variables for the lists.

--- a/www/pages/routes-and-stops/routes-and-stops.html
+++ b/www/pages/routes-and-stops/routes-and-stops.html
@@ -13,9 +13,9 @@
         <span style="color: #{{route.Color}}; font-size: 125%; font-weight: bold; margin-left: 10px">{{route.ShortName}}</span>
         <p>{{route.LongName}}</p>
       </ion-item>
-      <ion-item collection-repeat="stop in stopsDisp" href="#/app/stops/{{stop.id}}">
+      <ion-item collection-repeat="stop in stopsDisp" href="#/app/stops/{{stop.StopId}}">
         <i class="icon ion-ios-location" style="margin-right: 10px"></i>
-        {{stop.name}}
+        {{stop.Name}}
       </ion-item>
     </ion-list>
     <div ng-if="!routesDisp.length && !stopsDisp.length" class="bar bar-assertive title">


### PR DESCRIPTION
Closes #185.  Fixes an issue introduced with the new `Routes and Stops` page where clicking on a stop redirects you to the Stop page, but never actually loads any info about a real stop. 

It turned out there was some copied code from Search that, while functional for displaying, was excessive when trying to redirect.
