### PR TITLE
Stops Heart Fix

### DIFF
--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -39,10 +39,10 @@ angular.module('pvta.factories')
     });
   };
 
-  function contains (stop, cb) {
-    localforage.getItem('favoriteStops', function () {
+  function contains (stopId, cb) {
+    localforage.getItem('favoriteStops', function (err, stops) {
       if (stops) {
-        var r = _.where(stops, { StopId: stop.StopId });
+        var r = _.where(stops, { StopId: stopId });
         if (r.length > 0) {
           cb(true);
         }

--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -1,5 +1,6 @@
 angular.module('pvta.factories')
 .factory('FavoriteStops', function () {
+  var stops = [];
   var push = function (stop) {
     localforage.getItem('favoriteStops', function (err, stops) {
       var newStop = {StopId: stop.StopId, Name: stop.Name};

--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -42,8 +42,8 @@ angular.module('pvta.factories')
   function contains (stopId, cb) {
     localforage.getItem('favoriteStops', function (err, stops) {
       if (stops) {
-        var r = _.where(stops, { StopId: stopId });
-        if (r.length > 0) {
+        var filteredStops = _.where(stops, { StopId: stopId });
+        if (filteredStops.length > 0) {
           cb(true);
         }
         else {

--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -1,7 +1,5 @@
 angular.module('pvta.factories')
-
 .factory('FavoriteStops', function () {
-  var stops = [];
   var push = function (stop) {
     localforage.getItem('favoriteStops', function (err, stops) {
       var newStop = {StopId: stop.StopId, Name: stop.Name};

--- a/www/pages/stop/stop-controller.js
+++ b/www/pages/stop/stop-controller.js
@@ -23,7 +23,9 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
   // Used to allow the 'heart' in the view
   // to draw itself accordingly.
   var getHeart = function () {
-    FavoriteStops.contains($scope.stop, function (bool) {
+    console.log('get heart');
+    FavoriteStops.contains($scope.stop.StopId, function (bool) {
+      console.log(bool);
       $scope.liked = bool;
     });
   };
@@ -143,6 +145,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
    * localforage throws an error, set to 30s.
    ********************************************/
   $scope.$on('$ionicView.enter', function () {
+    getHeart();
     localforage.getItem('autoRefresh', function (err, value) {
       if (value) {
         if (value <= 1000) {
@@ -180,7 +183,8 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
 
   // Update whether this Stop is favorited.
   $scope.toggleHeart = function () {
-    FavoriteStops.contains($scope.stop, function (bool) {
+    console.log($scope.stop.StopId);
+    FavoriteStops.contains($scope.stop.StopId, function (bool) {
       if (bool) {
         FavoriteStops.remove($scope.stop);
       }

--- a/www/pages/stop/stop-controller.js
+++ b/www/pages/stop/stop-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('StopController', function ($scope, $stateParams, $resource, $location, $interval, $state, Stop, StopDeparture, moment, FavoriteStops, SimpleRoute) {
+angular.module('pvta.controllers').controller('StopController', function ($scope, $stateParams, $resource, $location, $interval, $state, Stop, StopDeparture, moment, FavoriteStops, SimpleRoute, $ionicLoading) {
   ga('set', 'page', '/stop.html');
   ga('send', 'pageview');
   // For a given RouteId, downloads the simplest
@@ -23,9 +23,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
   // Used to allow the 'heart' in the view
   // to draw itself accordingly.
   var getHeart = function () {
-    console.log('get heart');
     FavoriteStops.contains($scope.stop.StopId, function (bool) {
-      console.log(bool);
       $scope.liked = bool;
     });
   };
@@ -145,6 +143,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
    * localforage throws an error, set to 30s.
    ********************************************/
   $scope.$on('$ionicView.enter', function () {
+    $ionicLoading.show({});
     getHeart();
     localforage.getItem('autoRefresh', function (err, value) {
       if (value) {
@@ -155,11 +154,13 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
         timer = $interval(function () {
           $scope.getDepartures();
         }, value);
+        $ionicLoading.hide();
       }
       else {
         timer = $interval(function () {
           $scope.getDepartures();
         }, 30000);
+        $ionicLoading.hide();
         console.log(err);
       }
     });
@@ -183,9 +184,8 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
 
   // Update whether this Stop is favorited.
   $scope.toggleHeart = function () {
-    console.log($scope.stop.StopId);
     FavoriteStops.contains($scope.stop.StopId, function (bool) {
-      if (bool) {
+      if (bool === true) {
         FavoriteStops.remove($scope.stop);
       }
       else {


### PR DESCRIPTION
I found about this error just the other day; for some time now, the version of the Stop page on master doesn't correctly display whether the stop currently onscreen is in the user's favorites.

This PR makes some changes to the FavoriteStops service to solidify it and adds an `ionicLoading` window to the Stop page that fires every time the pages is loaded to ensure that everything we want rendered is actually rendered before we present the page to the user. 
