### PR TITLE
Make Stop IDs More Prominent

### DIFF
--- a/www/pages/my-buses/mybuses.html
+++ b/www/pages/my-buses/mybuses.html
@@ -26,7 +26,7 @@
         <ion-option-button class="button-assertive icon ion-trash-a" ng-click="removeStop(stop, $index)"></ion-option-button>
         <div class="item-icon-left">
           <i class="icon ion-ios-location" style="margin-right: 10px"></i>
-          {{stop.Name}}
+          {{stop.Name}} ({{stop.StopId}})
         </div>
       </ion-item>
       <a class="item item-icon-left item-text-wrap" href="#/app/routes-and-stops/1">

--- a/www/pages/route/route.html
+++ b/www/pages/route/route.html
@@ -64,8 +64,8 @@
           </div>
         </ion-item>
         <ion-scroll zooming="false" direction="y" style="width:100%; height: 200px;" ng-show="isGroupShown(stops)">
-          <ion-item ng-repeat="item in stops | orderBy: '+Name'" href="#/app/stops/{{item.StopId}}">
-            {{item.Name}}
+          <ion-item ng-repeat="stop in stops | orderBy: '+Name'" href="#/app/stops/{{stop.StopId}}">
+            {{stop.Name}} ({{stop.StopId}})
           </ion-item>
         </ion-scroll>
       </ion-list>

--- a/www/pages/routes-and-stops/routes-and-stops.html
+++ b/www/pages/routes-and-stops/routes-and-stops.html
@@ -15,7 +15,7 @@
       </ion-item>
       <ion-item collection-repeat="stop in stopsDisp" href="#/app/stops/{{stop.StopId}}">
         <i class="icon ion-ios-location" style="margin-right: 10px"></i>
-        {{stop.Name}}
+        {{stop.Name}} ({{stop.StopId}})
       </ion-item>
     </ion-list>
     <div ng-if="!routesDisp.length && !stopsDisp.length" class="bar bar-assertive title">

--- a/www/pages/stop/stop.html
+++ b/www/pages/stop/stop.html
@@ -1,5 +1,5 @@
 <ion-view>
-  <ion-nav-title>Departures: {{stop.Name}}</ion-nav-title>
+  <ion-nav-title>Departures: {{stop.Name}} ({{stop.StopId}})</ion-nav-title>
   <ion-nav-buttons side="secondary">
     <button id="like"  ng-class="{'button button-icon icon ion-ios-heart': liked, 'button button-icon icon ion-ios-heart-outline': !liked}" ng-click="liked= !liked; toggleHeart(liked)"></button>
   </ion-nav-buttons>


### PR DESCRIPTION
Closes #153.  Now, whenever we have a stop name, it will be in the format `stop_name (stop_id)`.

It's not overly elegant, but it's simple, obvious, and in-line with Avail's site(s).  

<img width="1440" alt="screen shot 2016-09-09 at 12 59 00 pm" src="https://cloud.githubusercontent.com/assets/7144148/18395661/6877d9d2-768d-11e6-85f4-42f8587c6bd0.png">
