### PR TITLE
Add realtime data disclaimer to stop departures page

### DIFF
--- a/www/css/style.css
+++ b/www/css/style.css
@@ -43,7 +43,6 @@ margin:5px;
   width:25%;
 }
 
-/* Empty. Add your own CSS if you like */
 #stop-map {
   height: 50%;
 }
@@ -57,4 +56,11 @@ margin:5px;
   float: top;
   overflow: auto;
   width: 100%;
+}
+
+.disclaimer {
+  color: grey;
+  font-size: small;
+  font-style: italic;
+  text-align: center;
 }

--- a/www/pages/stop/stop.html
+++ b/www/pages/stop/stop.html
@@ -58,6 +58,10 @@
     <div ng-if="!departuresByRoute.length">
       <ion-item class="item item-assertive" style="text-align:center">{{stop.Name}} has no departures for at least the next 3 hours.</ion-item>
     </div>
+    <div>
+      <p class="disclaimer">Disclaimer: Real-time data is an estimate and may be incorrect or unavailable.<br>
+      Please continue to reference official schedules as necessary.</p>
+    </div>
   </ion-content>
   <ion-footer-bar class="bar-positive">
       <button class="button icon-center ion-ios-location title" ng-click="setCoordinates()">


### PR DESCRIPTION
Closes #147.  Adds a disclaimer to the Stop Departures page.

<img width="505" alt="screen shot 2016-09-12 at 10 00 23 pm" src="https://cloud.githubusercontent.com/assets/7144148/18459050/77210ef0-7934-11e6-9648-e40f38b9c88a.png">
