### PR TITLE
Stop Getting Directions to Stops by Default

### DIFF
--- a/www/factories/map-factories.js
+++ b/www/factories/map-factories.js
@@ -27,7 +27,9 @@ angular.module('pvta.factories')
       if (cb) {
         cb(currentLocation);
       }
-    }, function () {});
+    }, function () {
+      cb(false);
+    });
     return currentLocation;
   }
 

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -35,7 +35,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
         title: 'Unable to Map Stop',
         template: 'A network error occurred. Please make sure your device has an internet connection.'
       });
-      popup.then(function(res) {
+      popup.then(function () {
         $ionicHistory.goBack();
       });
     }
@@ -46,14 +46,14 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
    * to the stop in question and displays them on the UI.
   */
   $scope.calculateDirections = function () {
-    $ionicLoading.show({duration: 5000})
+    $ionicLoading.show({duration: 5000});
     // A callback that we pass to the plotCurrentLocation
     // function below.  Handles actually getting
     // and displaying directions once we have a location.
     var cb = function (position) {
       // If we weren't able to get a location for any reason,
       // we should encounter a falsy.
-      if (position == false) {
+      if (!position) {
         console.log('unable to get current location');
         $scope.noLocation = true;
         $scope.displayDirections = false;
@@ -90,7 +90,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
     // the other when not.
     // Check which id the map has, pluck it from the HTML, and bind it
     // to a variable.
-    $scope.map = new google.maps.Map(document.getElementById($scope.displayDirections? 'stop-map' : 'map'), mapOptions);
+    $scope.map = new google.maps.Map(document.getElementById($scope.displayDirections ? 'stop-map' : 'map'), mapOptions);
     Map.init($scope.map, bounds);
     // Be ready to display directions if the user requests them.
     directionsDisplay = new google.maps.DirectionsRenderer();
@@ -98,8 +98,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
     // Download the stop details and plot it on the map.
     $scope.stop = Stop.get({stopId: $stateParams.stopId}, function () {
       placeStop();
-      $ionicLoading.hide()
+      $ionicLoading.hide();
     });
   });
-
 });

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -2,6 +2,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
   ga('set', 'page', '/stop-map.html');
   ga('send', 'pageview');
   var bounds = new google.maps.LatLngBounds();
+  $scope.displayDirections = false;
   var directionsDisplay;
   var directionsService = new google.maps.DirectionsService();
 
@@ -14,41 +15,71 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
     mapTypeId: google.maps.MapTypeId.ROADMAP
   };
 
-  $scope.map = new google.maps.Map(document.getElementById('stop-map'), mapOptions);
-  Map.init($scope.map, bounds);
-
+  /****
+  * Plots a stop on the map.  When clicked, the marker
+  * will display a popup that gives some details about the stop.
+  * Stop data needs to already have been loaded before this
+  * function will succeed.
+  */
   function placeStop () {
-    var loc = new google.maps.LatLng($scope.stop.Latitude, $scope.stop.Longitude);
-    Map.addMapListener(Map.placeDesiredMarker(loc), 'Here is your stop!');
-    return loc;
+    if ($scope.stop.Latitude && $scope.stop.Longitude) {
+      var loc = new google.maps.LatLng($scope.stop.Latitude, $scope.stop.Longitude);
+      Map.addMapListener(Map.placeDesiredMarker(loc), $scope.stop.Name + ' (' + $scope.stop.StopId + ')');
+      return loc;
+    }
+    else {
+      $ionicPopup.alert({
+        title: 'Unable to Map Stop',
+        template: 'An error occurred. Please make sure your device has an internet connection.'
+      });
+    }
   }
 
-  function calculateDirections () {
+  $scope.calculateDirections = function () {
+    $ionicLoading.show({duration: 5000})
     var cb = function (position) {
-      start = position;
-      var end = placeStop();
-      var request = {
-        origin: start,
-        destination: end,
-        travelMode: google.maps.TravelMode.WALKING
-      };
-      directionsService.route(request, function (result, status) {
-        if (status === google.maps.DirectionsStatus.OK) {
-          directionsDisplay.setDirections(result);
-        }
-        $ionicLoading.hide();
-      });
+      if (position === false) {
+        console.log('unable to get current location');
+        $scope.noLocation = true;
+        $scope.displayDirections = false;
+      }
+      else {
+        $scope.noLocation = false;
+        $scope.displayDirections = true;
+        directionsDisplay.setPanel(document.getElementById('directions'));
+        start = position;
+        var end = placeStop();
+        var request = {
+          origin: start,
+          destination: end,
+          travelMode: google.maps.TravelMode.WALKING
+        };
+        directionsService.route(request, function (result, status) {
+          if (status === google.maps.DirectionsStatus.OK) {
+            directionsDisplay.setDirections(result);
+          }
+        });
+      }
+      $ionicLoading.hide();
     };
     Map.plotCurrentLocation(cb);
-  }
+  };
 
   $scope.$on('$ionicView.enter', function () {
     $ionicLoading.show({});
+    // The map div can have one of two ids: one when showing directions,
+    // the other when not.
+    // Check which id the map has, pluck it from the HTML, and bind it
+    // to a variable.
+    $scope.map = new google.maps.Map(document.getElementById($scope.displayDirections? 'stop-map' : 'map'), mapOptions);
+    Map.init($scope.map, bounds);
+    // Be ready to display directions if the user requests them.
     directionsDisplay = new google.maps.DirectionsRenderer();
     directionsDisplay.setMap($scope.map);
-    directionsDisplay.setPanel(document.getElementById('directions'));
+    // Download the stop details and plot it on the map.
     $scope.stop = Stop.get({stopId: $stateParams.stopId}, function () {
-      calculateDirections();
+      placeStop();
+      $ionicLoading.hide()
     });
   });
 

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -41,14 +41,25 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
     }
   }
 
+  /***
+   * Gets directions from the user's current location
+   * to the stop in question and displays them on the UI.
+  */
   $scope.calculateDirections = function () {
     $ionicLoading.show({duration: 5000})
+    // A callback that we pass to the plotCurrentLocation
+    // function below.  Handles actually getting
+    // and displaying directions once we have a location.
     var cb = function (position) {
-      if (position === false) {
+      // If we weren't able to get a location for any reason,
+      // we should encounter a falsy.
+      if (position == false) {
         console.log('unable to get current location');
         $scope.noLocation = true;
         $scope.displayDirections = false;
       }
+      // If we have a location, download and display directions
+      // from here to the stop.
       else {
         $scope.noLocation = false;
         $scope.displayDirections = true;
@@ -68,6 +79,8 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
       }
       $ionicLoading.hide();
     };
+    // Get the current location. Once we have (or definitively don't have)
+    // a location, the callback passed as a param will be called.
     Map.plotCurrentLocation(cb);
   };
 

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('StopMapController', function ($scope, $ionicLoading, $stateParams, Stop, Map) {
+angular.module('pvta.controllers').controller('StopMapController', function ($scope, $ionicLoading, $stateParams, $ionicPopup, Stop, Map) {
   ga('set', 'page', '/stop-map.html');
   ga('send', 'pageview');
   var bounds = new google.maps.LatLngBounds();
@@ -22,7 +22,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
   * function will succeed.
   */
   function placeStop () {
-    if ($scope.stop.Latitude && $scope.stop.Longitude) {
+    if ($scope.stop && $scope.stop.Latitude && $scope.stop.Longitude) {
       var loc = new google.maps.LatLng($scope.stop.Latitude, $scope.stop.Longitude);
       Map.addMapListener(Map.placeDesiredMarker(loc), $scope.stop.Name + ' (' + $scope.stop.StopId + ')');
       return loc;
@@ -30,7 +30,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
     else {
       $ionicPopup.alert({
         title: 'Unable to Map Stop',
-        template: 'An error occurred. Please make sure your device has an internet connection.'
+        template: 'A network error occurred. Please make sure your device has an internet connection.'
       });
     }
   }

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('StopMapController', function ($scope, $ionicLoading, $stateParams, $ionicPopup, Stop, Map) {
+angular.module('pvta.controllers').controller('StopMapController', function ($scope, $ionicLoading, $stateParams, $ionicHistory, $ionicPopup, Stop, Map) {
   ga('set', 'page', '/stop-map.html');
   ga('send', 'pageview');
   var bounds = new google.maps.LatLngBounds();
@@ -22,15 +22,21 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
   * function will succeed.
   */
   function placeStop () {
+    // If we have stop details, plot it.
     if ($scope.stop && $scope.stop.Latitude && $scope.stop.Longitude) {
       var loc = new google.maps.LatLng($scope.stop.Latitude, $scope.stop.Longitude);
       Map.addMapListener(Map.placeDesiredMarker(loc), $scope.stop.Name + ' (' + $scope.stop.StopId + ')');
       return loc;
     }
+    // If we don't have stop details, it means that we couldn't download any.
+    // Show an error dialog and go back to the last page.
     else {
-      $ionicPopup.alert({
+      var popup = $ionicPopup.alert({
         title: 'Unable to Map Stop',
         template: 'A network error occurred. Please make sure your device has an internet connection.'
+      });
+      popup.then(function(res) {
+        $ionicHistory.goBack();
       });
     }
   }

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -86,8 +86,8 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
 
   $scope.$on('$ionicView.enter', function () {
     $ionicLoading.show({});
-    // The map div can have one of two ids: one when showing directions,
-    // the other when not.
+    // The map div can have one of two ids:
+    // one when directions are being shown, the other when not.
     // Check which id the map has, pluck it from the HTML, and bind it
     // to a variable.
     $scope.map = new google.maps.Map(document.getElementById($scope.displayDirections ? 'stop-map' : 'map'), mapOptions);

--- a/www/pages/stop-map/stop-map.html
+++ b/www/pages/stop-map/stop-map.html
@@ -5,7 +5,8 @@
         Unable to retrieve current location.
       </ion-item>
     </div>
-    <div ng-attr-id="{{ displayDirections? 'stop-map' : 'map' }}"></div>
+    <!--Use angular to dynamically style the map div-->
+    <div ng-attr-id="{{ displayDirections ? 'stop-map' : 'map' }}"></div>
     <div id="directions"></div>
   </ion-content>
   <ion-footer-bar class="bar-positive">

--- a/www/pages/stop-map/stop-map.html
+++ b/www/pages/stop-map/stop-map.html
@@ -1,6 +1,16 @@
 <ion-view view-title="Map">
   <ion-content>
-    <div id="stop-map"></div>
+    <div ng-if="noLocation">
+      <ion-item class="item item-assertive" style="text-align:center">
+        Unable to retrieve current location.
+      </ion-item>
+    </div>
+    <div ng-attr-id="{{ displayDirections? 'stop-map' : 'map' }}"></div>
     <div id="directions"></div>
   </ion-content>
+  <ion-footer-bar class="bar-positive">
+      <button class="button icon-center ion-ios-location title" ng-click="calculateDirections()">
+        Get Directions to {{stop.Name}}
+      </button>
+  </ion-footer-bar>
 </ion-view>


### PR DESCRIPTION
Closes #114.  Adds a button bar to the bottom of the Stop Map page that allows you to request directions to the stop.  

By default, it will plot the stop, but nothing more (it no longer plots your location by default either, as that seemed distracting. If you want to cross-reference your location, you might as well just get directions).

Also adds some error checking and cleaner handling than existed before.  A red bar appears with a message if you try to get directions we can't get a location, and an alert popup brings you back to safety in the event that we try to map a stop before its details are downloaded.
