### PR TITLE
Fix Map Not Displaying Second Time on Desktops

### DIFF
--- a/www/pages/route-map/map.html
+++ b/www/pages/route-map/map.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Map">
+<ion-view cache-view="false" view-title="Map">
   <ion-content>
     <div id="map"></div>
   </ion-content>

--- a/www/pages/stop-map/stop-map.html
+++ b/www/pages/stop-map/stop-map.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Map">
+<ion-view cache-view="false" view-title="Map">
   <ion-content>
     <div ng-if="noLocation">
       <ion-item class="item item-assertive" style="text-align:center">

--- a/www/pages/vehicle-map/map.html
+++ b/www/pages/vehicle-map/map.html
@@ -1,4 +1,4 @@
-<ion-view view-title="Map">
+<ion-view cache-view="false" view-title="Map">
   <ion-content>
     <div id="map"></div>
   </ion-content>


### PR DESCRIPTION
Closes #124.  The solution to this issue is to disable "view caching" on the affected pages.  Ionic saves the view/controller and does something special when the back button is pressed that it doesn't do when simply navigating away from the page.  

That was what caused the problem, which appeared on any page with maps on desktop browsers (whenever the sidebar is snapped open).
