### PR TITLE
Fix Routes and Stops Issues

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,6 @@
     "angular-underscore-module": "~1.0.3",
     "angular-resource": "~1.5.0",
     "ion-datetime-picker": "^0.1.2",
-    "ti-segmented-control": "^0.0.2",
     "angular-mocks": "1.4.3"
   }
 }

--- a/www/app.js
+++ b/www/app.js
@@ -6,7 +6,7 @@
 // 'pvta.controllers' is found in controllers.js
 angular.module('pvta.controllers', ['pvta.factories']);
 angular.module('pvta.factories', ['ngResource']);
-angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment', 'jett.ionic.filter.bar', 'underscore', 'ion-datetime-picker', 'ti-segmented-control'])
+angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment', 'jett.ionic.filter.bar', 'underscore', 'ion-datetime-picker'])
 
 .run(function ($ionicPlatform) {
   $ionicPlatform.ready(function () {

--- a/www/index.html
+++ b/www/index.html
@@ -49,9 +49,6 @@
     <link rel="stylesheet" href="bower_components/ionic-filter-bar/dist/ionic.filter.bar.css">
     <script src="bower_components/ionic-filter-bar/dist/ionic.filter.bar.js"></script>
 
-    <!--segmented control for RoutesAndStops-->
-    <script src="bower_components/ti-segmented-control/dist/ti-segmented-control.js"></script>
-
     <!-- app's entry point and Google APIs -->
     <script src="app.js"></script>
     <!-- Dev API key stays on master, betasrv key gets swapped in when pushing to gh-pages -->

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -35,6 +35,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
         StopsForage.save(stops);
         stops = StopsForage.uniq(stops);
         $scope.stops = prepareStops(stops);
+        $scope.display($scope.currentDisplay);
       });
     }, function (err) {
       // If location services fail us, just
@@ -44,6 +45,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
         stops = StopsForage.uniq(stops);
         StopsForage.save(stops);
         $scope.stops = prepareStops(stops);
+        $scope.display($scope.currentDisplay);
       });
     });
     /* Similar to prepareRoutes, we only
@@ -125,5 +127,4 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     });
   };
   getItems();
-  $scope.display($scope.currentDisplay);
 });

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -1,7 +1,7 @@
 angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams) {
   // We can control which list is shown via the page's URL.
   // Pull that param and same it for later.
-  var currentDisplay = parseInt($stateParams.segment);
+  $scope.currentDisplay = parseInt($stateParams.segment);
   $ionicLoading.show({});
   /*
    * Get all the routes and stops
@@ -12,7 +12,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     RouteForage.get().then(function (routes) {
       RouteForage.save(routes);
       $scope.routes = stripDetails(routes);
-      $scope.display(currentDisplay);
+      $scope.display($scope.currentDisplay);
     });
     /*
     * Nested function for removing stuff we don't need
@@ -70,7 +70,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
      * which type of data is being displayed.
      * This is useful when searching.
      */
-    currentDisplay = index;
+    $scope.currentDisplay = index;
     /* Fill the $scope variable for
      * the proper list and clear out
      * the ones for the other list.
@@ -100,7 +100,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     // itms is the variable we'll be searching.
     // If routes are displayed, imts is routes.
     // Else, it's stops.
-    if (currentDisplay === 0) {
+    if ($scope.currentDisplay === 0) {
       itms = $scope.routesDisp;
     }
     else {
@@ -113,7 +113,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       update: function (filteredItems) {
         // if routes are currently being displayed, update
         // their list with our results here.
-        if (currentDisplay === 0) {
+        if ($scope.currentDisplay === 0) {
           $scope.routesDisp = filteredItems;
         }
         else {
@@ -125,4 +125,5 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     });
   };
   getItems();
+  $scope.display($scope.currentDisplay);
 });

--- a/www/pages/routes-and-stops/routes-and-stops.html
+++ b/www/pages/routes-and-stops/routes-and-stops.html
@@ -2,21 +2,26 @@
   <ion-nav-buttons side="secondary">
     <button class="button button-icon icon ion-ios-search-strong" ng-click="showFilterBar()"></button>
   </ion-nav-buttons>
-  <ion-content direction="y" scrollbar-y="false">
+  <div class="bar bar-subheader">
+    <div class="button-bar">
+      <button ng-class="currentDisplay === 0 ? 'button button-positive' : 'button  button-outline button-positive'" ng-click="display(0)">Routes</button>
+      <button ng-class="currentDisplay === 1 ? 'button button-positive' : 'button  button-outline button-positive'" ng-click="display(1)">Stops</button>
+    </div>
+  </div>
+  <ion-content class="has-subheader" direction="y" scrollbar-y="false">
+
+
     <ion-list>
-      <ti-segmented-control on-select="display($index)" style="width: 100%;">
-        <ti-segmented-control-button class="button-positive" title="'Routes'"></ti-segmented-control-button>
-        <ti-segmented-control-button class="button-positive" title="'Stops'"></ti-segmented-control-button>
-      </ti-segmented-control>
-      <ion-item class="item" ng-repeat="route in routesDisp" href="#app/routes/{{route.RouteId}}">
+      <ion-item ng-show="currentDisplay === 0" class="item" ng-repeat="route in routesDisp" href="#app/routes/{{route.RouteId}}">
         <i class="icon ion-android-bus"></i>
         <span style="color: #{{route.Color}}; font-size: 125%; font-weight: bold; margin-left: 10px">{{route.ShortName}}</span>
         <p>{{route.LongName}}</p>
       </ion-item>
-      <ion-item collection-repeat="stop in stopsDisp" href="#/app/stops/{{stop.StopId}}">
+      <ion-item ng-show="currentDisplay === 1" ng-repeat="stop in stopsDisp | limitTo: 200" href="#/app/stops/{{stop.StopId}}">
         <i class="icon ion-ios-location" style="margin-right: 10px"></i>
         {{stop.Name}} ({{stop.StopId}})
       </ion-item>
+      <div ng-if="currentDisplay === 1 && stopsDisp.length >= 100" class="item item-divider item-positive item-text-wrap">Too many stops to show. Please search above for your stop by name or ID.</div>
     </ion-list>
     <div ng-if="!routesDisp.length && !stopsDisp.length" class="bar bar-assertive title">
         <h1 class="title">No results found.</h1>


### PR DESCRIPTION
Closes #189 and #190.  I removed the mediocre `ti-segmented-control` plugin and wrote segmented control myself using conditional CSS classes.  As such, the style has changed.  

The issue in #190 was that ionic's `collection-repeat` directive was making it so that lists weren't scrollable at first.  Not sure how/why, but changing it to the slower `ng-repeat` fixed it.  As such, I limited the number of stops that can appear at once so that the app doesn't crawl when viewing the stop list.  I decided 200 stops at a time was a reasonable max.

Old look 

<img width="1165" alt="screen shot 2016-09-14 at 3 58 30 pm" src="https://cloud.githubusercontent.com/assets/7144148/18527775/2932e770-7a94-11e6-8aa7-abf5dfdab5e4.png">

 new look:

<img width="1165" alt="screen shot 2016-09-14 at 3 58 05 pm" src="https://cloud.githubusercontent.com/assets/7144148/18527772/2777eae8-7a94-11e6-9379-3372cbd47d36.png">
