### PR TITLE
Show Favorites in Routes and Stops

### DIFF
--- a/www/pages/route/route.html
+++ b/www/pages/route/route.html
@@ -8,15 +8,12 @@
       <div class="item-text-wrap">
         <h2 class="item" style="text-align: center; font-size: 150%">{{route.LongName}}</h2>
       </div>
-      <div class="bar bar-positive">
-        <h1 class="title">Buses currently on the {{route.ShortName}}:</h1>
+      <div ng-class="vehicles.length > 0 ? 'bar bar-positive' : 'bar bar-assertive'">
+        <h1 class="title" ng-if="vehicles.length > 0">Buses currently on the {{route.ShortName}}:</h1>
+        <h1 class="title" ng-if="vehicles.length === 0"> There are no buses currently on the {{route.ShortName}}.</h1>
       </div>
       <div style="padding-top: 40px;">
         <ion-list>
-          <div ng-if="vehicles.length === 0" style="text-align:center;">
-            None
-            <i class="icon ion-thumbsdown"></i>
-          </div>
           <ion-item class="item" ng-repeat="vehicle in vehicles" href="#/app/vehicles/{{vehicle.VehicleId}}/{{route.RouteId}}">
             <div class="row item-text-wrap" style="font-weight: bold;">
                 <div class="col" ng-if="vehicle.DisplayStatus==='On Time'" style="color: green; text-align: center;">

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -3,16 +3,17 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
   // Pull that param and same it for later.
   $scope.currentDisplay = parseInt($stateParams.segment);
   $ionicLoading.show({});
+  $scope._ = _;
   /*
    * Get all the routes and stops
    */
-  function getItems () {
+  function getRoutesAndStops () {
     $scope.routes = [];
     // RouteForage returns a promise, resolve it.
     RouteForage.get().then(function (routes) {
       RouteForage.save(routes);
       $scope.routes = stripDetails(routes);
-      $scope.display($scope.currentDisplay);
+      redraw();
     });
     /*
     * Nested function for removing stuff we don't need
@@ -35,7 +36,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
         StopsForage.save(stops);
         stops = StopsForage.uniq(stops);
         $scope.stops = prepareStops(stops);
-        $scope.display($scope.currentDisplay);
+        redraw();
       });
     }, function (err) {
       // If location services fail us, just
@@ -45,7 +46,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
         stops = StopsForage.uniq(stops);
         StopsForage.save(stops);
         $scope.stops = prepareStops(stops);
-        $scope.display($scope.currentDisplay);
+        redraw();
       });
     });
     /* Similar to prepareRoutes, we only
@@ -126,5 +127,23 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       }
     });
   };
-  getItems();
+  function getFavorites() {
+    localforage.getItem('favoriteRoutes', function (err, value) {
+      $scope.favoriteRoutes = value;
+      redraw();
+    });
+    localforage.getItem('favoriteStops', function (err, value) {
+      $scope.favoriteStops = value;
+      redraw();
+    });
+  }
+
+  function redraw() {
+    $scope.display($scope.currentDisplay);
+  }
+
+  $scope.$on('$ionicView.enter', function () {
+    getRoutesAndStops();
+    getFavorites();
+  });
 });

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -127,7 +127,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       }
     });
   };
-  function getFavorites() {
+  function getFavorites () {
     localforage.getItem('favoriteRoutes', function (err, value) {
       $scope.favoriteRoutes = value;
       redraw();
@@ -138,7 +138,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     });
   }
 
-  function redraw() {
+  function redraw () {
     $scope.display($scope.currentDisplay);
   }
 

--- a/www/pages/routes-and-stops/routes-and-stops.html
+++ b/www/pages/routes-and-stops/routes-and-stops.html
@@ -9,17 +9,17 @@
     </div>
   </div>
   <ion-content class="has-subheader" direction="y" scrollbar-y="false">
-
-
     <ion-list>
-      <ion-item ng-show="currentDisplay === 0" class="item" ng-repeat="route in routesDisp" href="#app/routes/{{route.RouteId}}">
+      <ion-item ng-show="currentDisplay === 0" class="item item-icon-left item-icon-right" ng-repeat="route in routesDisp" href="#app/routes/{{route.RouteId}}">
         <i class="icon ion-android-bus"></i>
         <span style="color: #{{route.Color}}; font-size: 125%; font-weight: bold; margin-left: 10px">{{route.ShortName}}</span>
         <p>{{route.LongName}}</p>
+        <i ng-show="_.contains(_.pluck(favoriteRoutes, 'RouteId'), route.RouteId)" class="icon ion-ios-heart"></i>
       </ion-item>
-      <ion-item ng-show="currentDisplay === 1" ng-repeat="stop in stopsDisp | limitTo: 200" href="#/app/stops/{{stop.StopId}}">
+      <ion-item ng-show="currentDisplay === 1" class="item item-icon-left item-icon-right" ng-repeat="stop in stopsDisp | limitTo: 200" href="#/app/stops/{{stop.StopId}}">
         <i class="icon ion-ios-location" style="margin-right: 10px"></i>
         {{stop.Name}} ({{stop.StopId}})
+        <i ng-show="_.contains(_.pluck(favoriteStops, 'StopId'), stop.StopId)" class="icon ion-ios-heart"></i>
       </ion-item>
       <div ng-if="currentDisplay === 1 && stopsDisp.length >= 100" class="item item-divider item-positive item-text-wrap">Too many stops to show. Please search above for your stop by name or ID.</div>
     </ion-list>


### PR DESCRIPTION
Closes #198.  Adds a heart next to the name of a favorited route or stop in `Routes and Stops`.  Also updates how the Route page looks when there's no buses on it.

**Before:**

<img width="1440" alt="screen shot 2016-09-09 at 12 59 00 pm" src="https://cloud.githubusercontent.com/assets/7144148/18538184/42956a9a-7ad9-11e6-80d3-7cbb94e5a53d.png">

**After:**
<img width="570" alt="screen shot 2016-09-15 at 12 10 50 am" src="https://cloud.githubusercontent.com/assets/7144148/18538206/62e37922-7ad9-11e6-8d61-74a043827563.png">

**Before:**
<img width="504" alt="screen shot 2016-09-15 at 12 15 53 am" src="https://cloud.githubusercontent.com/assets/7144148/18538225/9fb5745e-7ad9-11e6-9c5a-6245a7626d5c.png">

**After:**
<img width="570" alt="screen shot 2016-09-15 at 12 10 10 am" src="https://cloud.githubusercontent.com/assets/7144148/18538227/a70ab160-7ad9-11e6-9f05-214e2f33459a.png">
