### PR TITLE
Fix Route Not Redirecting To Route Map

### DIFF
--- a/www/pages/route/route.html
+++ b/www/pages/route/route.html
@@ -69,8 +69,8 @@
     </div>
   </ion-content>
   <ion-footer-bar class="bar-positive">
-    <button class="button icon-center ion-ios-location title" href="#/app/route-map/{{route.RouteId}}">
+    <a class="button icon-center ion-ios-location" href="#/app/map/route/{{route.RouteId}}">
       Map This Route
-    </button>
+    </a>
   </ion-footer-bar>
 </ion-view>

--- a/www/pages/stop/stop.html
+++ b/www/pages/stop/stop.html
@@ -67,7 +67,5 @@
       <button class="button icon-center ion-ios-location title" ng-click="setCoordinates()">
         Find on map
       </button>
-
-
   </ion-footer-bar>
 </ion-view>


### PR DESCRIPTION
Closes #216.  

There were 2 issues here that I somehow missed: the URL was wrong, and we can't use `href` redirects with `<button>`s.  

Changing the URL (`#/app/map/route`, not `#/app/route-map`) and switching `<button>` to `<a>` solved the problem.
