### PR TITLE
Streamline Loaders on Route Page

### DIFF
--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -1,11 +1,18 @@
 angular.module('pvta.controllers').controller('RouteController', function($scope, $state, $stateParams, $ionicLoading, Route, RouteVehicles, FavoriteRoutes, Messages){
   ga('set', 'page', '/route.html');
   ga('send', 'pageview');
-  $ionicLoading.show();
-  var getVehicles = function(){
-    $scope.vehicles = RouteVehicles.query({id: $stateParams.routeId});
+
+  /*
+  * Called when the user performs a pull-to-refresh.  Only downloads
+  * vehicle data instead of all route data.
+  */
+  function getVehicles (){
+    $scope.vehicles = RouteVehicles.query({id: $stateParams.routeId}, function () {
+    $scope.$broadcast('scroll.refreshComplete');
+    });
   };
 
+  $ionicLoading.show();
   var route = Route.get({routeId: $stateParams.routeId}, function() {
     route.$save();
     getHeart();
@@ -58,11 +65,9 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
 
   $scope.refresh = function(){
     getVehicles();
-    $scope.$broadcast('scroll.refreshComplete');
   };
 
   $scope.$on('$ionicView.enter', function(){
     getHeart();
-    getVehicles();
   });
 });

--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -16,7 +16,6 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
   var route = Route.get({routeId: $stateParams.routeId}, function() {
     route.$save();
     getHeart();
-    $ionicLoading.hide();
     $scope.stops = route.Stops;
     $scope.vehicles = route.Vehicles;
 
@@ -27,6 +26,7 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
         if(message.Routes.indexOf($scope.route.RouteId) === -1) { continue; }
         filteredMessages.push(message);
       }
+      $ionicLoading.hide();
       $scope.messages = filteredMessages;
     });
   });

--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -31,10 +31,7 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
     });
   });
   $scope.route = route;
-
-
   $scope.stops = [];
-  var j = $scope.size;
 
   $scope.toggleGroup = function(group) {
     if ($scope.isGroupShown(group)) {

--- a/www/pages/route/route.html
+++ b/www/pages/route/route.html
@@ -69,7 +69,7 @@
     </div>
   </ion-content>
   <ion-footer-bar class="bar-positive">
-    <a class="button icon-center ion-ios-location" href="#/app/map/route/{{route.RouteId}}">
+    <a class="button icon-center ion-ios-location title" href="#/app/map/route/{{route.RouteId}}">
       Map This Route
     </a>
   </ion-footer-bar>


### PR DESCRIPTION
Closes #128.  The last page to have loader fixes.  Also, no longer GETs RouteVehicles when we navigate to this page, because they're downloaded _with_ the Route object.  When the user pulls to refresh the page, we then will download (only) the vehicles again.  We now use the pull-to-refresh loader here instead of the normal $ionicLoader, which is cleaner.
