### PR TITLE
Add Contact Page

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -150,6 +150,15 @@ angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment
         controller: 'PrivacyPolicyController'
       }
     }
+  })
+  .state('app.contact', {
+    url: '/about/contact',
+    views: {
+      'menuContent': {
+        templateUrl: 'pages/contact/contact.html',
+        controller: 'ContactController'
+      }
+    }
   });
   // if none of the above states are matched, use this as the fallback
   $urlRouterProvider.otherwise('/app/my-buses');

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -73,7 +73,7 @@ margin:5px;
   margin-left: 30%;
 }
 
-.button {
+.button-contact-page {
   width:2.5em;
 }
 

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -68,3 +68,11 @@ margin:5px;
   font-style: italic;
   text-align: center;
 }
+.ion-social-facebook {
+  margin-left: 30%;
+}
+
+.button {
+  width:2.5em;
+
+}

--- a/www/index.html
+++ b/www/index.html
@@ -78,6 +78,7 @@
     <script src="pages/about/about-controller.js"></script>
     <script src="pages/storage-settings/storage-settings-controller.js"></script>
     <script src="pages/privacy-policy/privacy-policy-controller.js"></script>
+    <script src="pages/contact/contact-controller.js"></script>
     <!--Factories and services-->
     <script src="factories/data-factories.js"></script>
     <script src="factories/favorite-routes-factories.js"></script>

--- a/www/pages/about/about.html
+++ b/www/pages/about/about.html
@@ -28,6 +28,10 @@
         <i class="icon ion-lock-combination"></i>
         View our Privacy Policy
       </a>
+      <a class="item item-icon-left" href="#/app/about/contact">
+        <i class="icon ion-android-call"></i>
+        Contact PVTA
+      </a>
     </div>
   </ion-content>
 </ion-view>

--- a/www/pages/contact/contact-controller.js
+++ b/www/pages/contact/contact-controller.js
@@ -1,0 +1,24 @@
+angular.module('pvta.controllers').controller('ContactController', function ($scope, $window) {
+  ga('set', 'page', '/about/contact.html');
+  ga('send', 'pageview');
+  /*
+    Opens a given URL in the browser.
+  */
+  $scope.openLink = function (url) {
+    console.log('Opening ' + url + ' in the browser');
+    // If we're on a device, we have to use cordova
+    // to open the default browser
+    if ($window.cordova) {
+      // We have to make sure that cordova is properly loaded before
+      // using one of its plugins.
+      document.addEventListener('deviceready', function () {
+        cordova.InAppBrowser.open(url, '_system');
+      }, false);
+    }
+    // If we're running as a web-app in a standard browser,
+    // we can just open the link in a new tab.
+    else {
+      $window.open(url);
+    }
+  };
+});

--- a/www/pages/contact/contact.html
+++ b/www/pages/contact/contact.html
@@ -8,13 +8,13 @@
       <div class="item item-button-right">
         PVTA Customer Service:
         <span class="item-note">413-781-PVTA (7882)</span>
-        <a class="button button-positive" href="tel:413-781-7882">
+        <a class="button button-positive button-contact-page" href="tel:413-781-7882">
           <i class="icon ion-android-call"></i>
         </a>
       </div>
       <div class="item item-button-right">
         Online Complaints/Concerns Form
-        <a class="button button-positive" href="#"
+        <a class="button button-positive button-contact-page" href="#"
           ng-click="openLink('http://pvta.com/contactComplaints.php')">
                 <i class="icon ion-ios-world-outline"></i>
         </a>
@@ -27,28 +27,28 @@
       <div class="item item-button-right">
         Springfield Area:
         <span class="item-note">413-788-8630</span>
-        <a class="button button-positive" href="tel:413-788-8630">
+        <a class="button button-positive button-contact-page" href="tel:413-788-8630">
           <i class="icon ion-android-call"></i>
         </a>
       </div>
       <div class="item item-button-right">
         Holyoke Transportation Center:
         <span class="item-note">413-536-0694</span>
-        <a class="button button-positive" href="tel:413-536-0694">
+        <a class="button button-positive button-contact-page" href="tel:413-536-0694">
           <i class="icon ion-android-call"></i>
         </a>
       </div>
       <div class="item item-button-right" href="tel:413-586-3548">
         Northampton Area:
         <span class="item-note">413-586-3548</span>
-        <a class="button button-positive" href="tel:413-586-3548">
+        <a class="button button-positive button-contact-page" href="tel:413-586-3548">
           <i class="icon ion-android-call"></i>
         </a>
       </div>
       <div class="item item-button-right">
         UMass Amherst Area:
         <span class="item-note">413-545-0056</span>
-        <a class="button button-positive" href="tel:413-545-0056">
+        <a class="button button-positive button-contact-page" href="tel:413-545-0056">
           <i class="icon ion-android-call"></i>
         </a>
       </div>
@@ -59,21 +59,21 @@
       </div>
       <div class="item item-button-right">
         PVTA Facebook
-        <a class="button button-positive" href="#"
+        <a class="button button-positive button-contact-page" href="#"
           ng-click="openLink('https://www.facebook.com/Pioneer-Valley-Transit-Authority-169604739716541')">
                 <i class="icon ion-social-facebook"></i>
         </a>
       </div>
       <div class="item item-button-right">
         PVTA Twitter
-        <a class="button button-positive" href="#"
+        <a class="button button-positive button-contact-page" href="#"
           ng-click="openLink('https://twitter.com/pvta')">
                 <i class="icon ion-social-twitter"></i>
         </a>
       </div>
       <div class="item item-button-right">
         UMass Transit Facebook
-        <a class="button button-positive" href="#"
+        <a class="button button-positive button-contact-page" href="#"
           ng-click="openLink('https://www.facebook.com/UMassTransit')">
                 <i class="icon ion-social-facebook"></i>
         </a>
@@ -81,7 +81,7 @@
 
       <div class="item item-button-right">
         UMass Transit Twitter
-        <a class="button button-positive" href="#"
+        <a class="button button-positive button-contact-page" href="#"
           ng-click="openLink('https://twitter.com/umasstransit')">
                 <i class="icon ion-social-twitter"></i>
         </a>
@@ -94,7 +94,7 @@
       <div class="item item-button-right">
         PVTA Paratransit Van Requests:
         <span class="item-note">413-732-6248, ext. 214</span>
-        <a class="button button-positive" href="tel:413-732-6248">
+        <a class="button button-positive button-contact-page" href="tel:413-732-6248">
           <i class="icon ion-android-call"></i>
         </a>
       </div>

--- a/www/pages/contact/contact.html
+++ b/www/pages/contact/contact.html
@@ -1,5 +1,6 @@
 <ion-view view-title="Contact">
   <ion-content>
+    <div class="list">
     <div class="list card item-text-wrap">
       <div class="item item-divider">
         PVTA
@@ -18,6 +19,8 @@
                 <i class="icon ion-ios-world-outline"></i>
         </a>
       </div>
+    </div>
+    <div class="list card item-text-wrap">
       <div class="item item-divider">
         Lost and Found / Regional Bus Information
       </div>
@@ -49,23 +52,54 @@
           <i class="icon ion-android-call"></i>
         </a>
       </div>
+    </div>
+    <div class="list card item-text-wrap">
+      <div class="item item-divider">
+        Social Media
+      </div>
+      <div class="item item-button-right">
+        PVTA Facebook
+        <a class="button button-positive" href="#"
+          ng-click="openLink('https://www.facebook.com/Pioneer-Valley-Transit-Authority-169604739716541')">
+                <i class="icon ion-social-facebook"></i>
+        </a>
+      </div>
+      <div class="item item-button-right">
+        PVTA Twitter
+        <a class="button button-positive" href="#"
+          ng-click="openLink('https://twitter.com/pvta')">
+                <i class="icon ion-social-twitter"></i>
+        </a>
+      </div>
+      <div class="item item-button-right">
+        UMass Transit Facebook
+        <a class="button button-positive" href="#"
+          ng-click="openLink('https://www.facebook.com/UMassTransit')">
+                <i class="icon ion-social-facebook"></i>
+        </a>
+      </div>
+
+      <div class="item item-button-right">
+        UMass Transit Twitter
+        <a class="button button-positive" href="#"
+          ng-click="openLink('https://twitter.com/umasstransit')">
+                <i class="icon ion-social-twitter"></i>
+        </a>
+      </div>
+    </div>
+    <div class="list card item-text-wrap">
       <div class="item item-divider">
         Paratransit Van Requests
       </div>
       <div class="item item-button-right">
-        PVTA Paratransit Van Requests (All Areas):
+        PVTA Paratransit Van Requests:
         <span class="item-note">413-732-6248, ext. 214</span>
         <a class="button button-positive" href="tel:413-732-6248">
           <i class="icon ion-android-call"></i>
         </a>
       </div>
-      <div class="item item-button-right">
-        UMass SpecTrans Requests (UMass Community Members Only):
-        <span class="item-note">(413) 545-2086</span>
-        <a class="button button-positive" href="tel:(413) 545-2086">
-          <i class="icon ion-android-call"></i>
-        </a>
-      </div>
+
     </div>
+</div>
   </ion-content>
 </ion-view>

--- a/www/pages/contact/contact.html
+++ b/www/pages/contact/contact.html
@@ -1,0 +1,71 @@
+<ion-view view-title="Contact">
+  <ion-content>
+    <div class="list card item-text-wrap">
+      <div class="item item-divider">
+        PVTA
+      </div>
+      <div class="item item-button-right">
+        PVTA Customer Service:
+        <span class="item-note">413-781-PVTA (7882)</span>
+        <a class="button button-positive" href="tel:413-781-7882">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+      <div class="item item-button-right">
+        Online Complaints/Concerns Form
+        <a class="button button-positive" href="#"
+          ng-click="openLink('http://pvta.com/contactComplaints.php')">
+                <i class="icon ion-ios-world-outline"></i>
+        </a>
+      </div>
+      <div class="item item-divider">
+        Lost and Found / Regional Bus Information
+      </div>
+      <div class="item item-button-right">
+        Springfield Area:
+        <span class="item-note">413-788-8630</span>
+        <a class="button button-positive" href="tel:413-788-8630">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+      <div class="item item-button-right">
+        Holyoke Transportation Center:
+        <span class="item-note">413-536-0694</span>
+        <a class="button button-positive" href="tel:413-536-0694">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+      <div class="item item-button-right" href="tel:413-586-3548">
+        Northampton Area:
+        <span class="item-note">413-586-3548</span>
+        <a class="button button-positive" href="tel:413-586-3548">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+      <div class="item item-button-right">
+        UMass Amherst Area:
+        <span class="item-note">413-545-0056</span>
+        <a class="button button-positive" href="tel:413-545-0056">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+      <div class="item item-divider">
+        Paratransit Van Requests
+      </div>
+      <div class="item item-button-right">
+        PVTA Paratransit Van Requests (All Areas):
+        <span class="item-note">413-732-6248, ext. 214</span>
+        <a class="button button-positive" href="tel:413-732-6248">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+      <div class="item item-button-right">
+        UMass SpecTrans Requests (UMass Community Members Only):
+        <span class="item-note">(413) 545-2086</span>
+        <a class="button button-positive" href="tel:(413) 545-2086">
+          <i class="icon ion-android-call"></i>
+        </a>
+      </div>
+    </div>
+  </ion-content>
+</ion-view>


### PR DESCRIPTION
Closes #211.  Adds a Contact page at `/about/contact` that gives a bunch of phone numbers for passengers.  Nothing special here.  @sherson, @werebus, @petermarathas, and @bgregg, any thoughts on UI or numbers/links that should or should not be included?

<img width="1058" alt="screen shot 2016-09-25 at 10 56 35 pm" src="https://cloud.githubusercontent.com/assets/7144148/18821392/a84480ae-8373-11e6-9bc4-78210eca702a.png">
