### PR TITLE
UX Tweaks on Routes& Stops

### DIFF
--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -4,13 +4,12 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
   // We can control which list is shown via the page's URL.
   // Pull that param and same it for later.
   $scope.currentDisplay = parseInt($stateParams.segment);
-  $ionicLoading.show({});
   $scope._ = _;
   /*
    * Get all the routes and stops
    */
   function getRoutesAndStops () {
-    $scope.routes = [];
+    $ionicLoading.show();
     // RouteForage returns a promise, resolve it.
     RouteForage.get().then(function (routes) {
       RouteForage.save(routes);
@@ -32,6 +31,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       stops = StopsForage.uniq(stops);
       $scope.stops = prepareStops(stops);
       StopsForage.save(stops);
+      $ionicLoading.hide();
       redraw();
     });
 
@@ -74,8 +74,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
         $scope.stopsDisp = $scope.stops.slice(0, 41);
         break;
     }
-    // Finally, hide the loader to coax a redraw.
-    $ionicLoading.hide();
   };
 
   /* When the search button is clicked onscreen,

--- a/www/pages/routes-and-stops/routes-and-stops.html
+++ b/www/pages/routes-and-stops/routes-and-stops.html
@@ -23,7 +23,7 @@
       </ion-item>
       <div ng-if="currentDisplay === 1 && stopsDisp.length >= 40" class="item item-divider item-positive item-text-wrap">Too many stops to show. Please search above for your stop by name or ID.</div>
     </ion-list>
-    <div ng-if="!routesDisp.length && !stopsDisp.length" class="bar bar-assertive title">
+    <div ng-if="routes && stops && !routesDisp.length && !stopsDisp.length" class="bar bar-assertive title">
         <h1 class="title">No results found.</h1>
     </div>
   </ion-content>

--- a/www/pages/routes-and-stops/routes-and-stops.html
+++ b/www/pages/routes-and-stops/routes-and-stops.html
@@ -21,7 +21,7 @@
         {{stop.Name}} ({{stop.StopId}})
         <i ng-show="_.contains(_.pluck(favoriteStops, 'StopId'), stop.StopId)" class="icon ion-ios-heart"></i>
       </ion-item>
-      <div ng-if="currentDisplay === 1 && stopsDisp.length >= 40" class="item item-divider item-positive item-text-wrap">Too many stops to show. Please search above for your stop by name or ID.</div>
+      <div ng-if="currentDisplay === 1 && stopsDisp" class="item item-divider item-positive item-text-wrap">Too many stops to show. Please search above for your stop by name or ID.</div>
     </ion-list>
     <div ng-if="routes && stops && !routesDisp.length && !stopsDisp.length" class="bar bar-assertive title">
         <h1 class="title">No results found.</h1>

--- a/www/pages/stop/stop.html
+++ b/www/pages/stop/stop.html
@@ -12,7 +12,7 @@
       Tap a route to view more departures
     </div>
     <ion-list ng-repeat="routeDepartures in departuresByRoute">
-      <ion-item ng-click="toggleRouteDropdown({{routeDepartures.RouteId}})"
+      <ion-item ng-click="toggleRouteDropdown(routeDepartures.RouteId)"
                       ng-class="{active: isRouteDropdownShown({{routeDepartures.RouteId}})}"
                       style="background-color: #{{routeList[routeDepartures.RouteId].Color}};">
         <div class="row item-text-wrap white">


### PR DESCRIPTION
This PR removes the red "NO RESULTS" bar from the Routes and Stops page when the data is still loading. It's currently kind of confusing to see immediately that there are no results the first time you ever navigate to the page.

Additionally, I added a loader that blocks user interaction until the Stops list has been displayed. Currently, navigating to the Stops list will just show a white screen until the data has finished downloading from Avail.

Hiding the loader only after stops are downloaded is a controversial design decision, but I think it's best because it's just about guaranteed that Stops will be the last thing to be ready, so once they are, we can unblock.

Finally, there's a small syntax error in HTML that was fixed.