### PR TITLE
Remove footer from plan-trip

### DIFF
--- a/www/pages/plan-trip/plan-trip.html
+++ b/www/pages/plan-trip/plan-trip.html
@@ -58,12 +58,6 @@
     <p><b>{{direction}}</b></p>
     </ion-item>
     </ion-list>
-    <div class="item item-divider item-positive">Not the trip you want?
-      <button class="button button-outline button-light icon-left" ng-click="openDatePicker(true)">
-        <i class="ion-calendar"></i>
-        Pick another time.
-      </button>
-    </div>
   </div>
   </ion-content>
 </ion-view>


### PR DESCRIPTION
Closes #258.  Simply removes the footer that contained the content which spawned the issue, because @sherson and I deemed it pointless to keep because users can just scroll up.