### PR TITLE
No Location Popup

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget id="com.umts.pvtamultiplaform" version="v0.9.0-rc.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.umts.pvtamultiplaform" version="v0.9.3-rc.3" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>PVTA</name>
   <description>
         The best way to find your buses on the go.

--- a/www/factories/info-factories.js
+++ b/www/factories/info-factories.js
@@ -82,8 +82,8 @@ angular.module('pvta')
 
 
   return {
-    versionNum: '0.9.0',
-    versionName: 'Release Candidate 2',
+    versionNum: '0.9.3',
+    versionName: 'Release Candidate 3',
     performMigrations: performMigrations,
     showPopups: showPopups
   };

--- a/www/factories/map-factories.js
+++ b/www/factories/map-factories.js
@@ -1,6 +1,6 @@
 angular.module('pvta.factories')
 
-.factory('Map', function ($cordovaGeolocation) {
+.factory('Map', function ($cordovaGeolocation, $ionicPopup) {
 
   var map;
   var currentLocation;
@@ -26,8 +26,9 @@ angular.module('pvta.factories')
         cb(currentLocation);
       }
     }, function (err) {
+      showInsecureOriginLocationPopup(err);
       // Tell Google Analytics that a user doesn't have location
-      ga('send', 'event', 'LocationFailure', '$cordovaGeolocation.getCurrentPosition', 'location failed in the Map Factory; error: '+ err.msg);
+      ga('send', 'event', 'LocationFailure', '$cordovaGeolocation.getCurrentPosition', 'location failed in the Map Factory; error: ' + err.message);
       if (cb) {
         cb(false);
       }
@@ -68,7 +69,17 @@ angular.module('pvta.factories')
     return $cordovaGeolocation.getCurrentPosition(options);
   }
 
+  function showInsecureOriginLocationPopup (err) {
+    if (err.code === 1 && err.message === 'Only secure origins are allowed (see: https://goo.gl/Y0ZkNV).') {
+      $ionicPopup.alert({
+        title: 'Location Features Disabled',
+        template: 'We\'ve temporarily disabled using your current location in PVTrAck, so this page might work a little differently than usual.<br>Sorry for the inconvenience!'
+      });
+    }
+  }
+
   return {
+    showInsecureOriginLocationPopup: showInsecureOriginLocationPopup,
     getCurrentPosition: getCurrentPosition,
     placeDesiredMarker: placeDesiredMarker,
     init: function (incomingMap) {

--- a/www/pages/plan-trip/plan-trip-controller.js
+++ b/www/pages/plan-trip/plan-trip-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('PlanTripController', function ($scope, $location, $state, $q, $cordovaGeolocation, $ionicLoading, $ionicPopup, $ionicScrollDelegate, NearestStop, Trips, $timeout, ionicDatePicker, ionicTimePicker) {
+angular.module('pvta.controllers').controller('PlanTripController', function ($scope, $location, $state, $q, $cordovaGeolocation, $ionicLoading, $ionicPopup, $ionicScrollDelegate, NearestStop, Trips, $timeout, ionicDatePicker, ionicTimePicker, Map) {
   ga('set', 'page', '/plan-trip.html');
   ga('send', 'pageview');
   defaultMapCenter = new google.maps.LatLng(42.3918143, -72.5291417);//Coords for UMass Campus Center
@@ -51,8 +51,9 @@ angular.module('pvta.controllers').controller('PlanTripController', function ($s
         }
       });
     }, function (err) {
+      Map.showInsecureOriginLocationPopup(err);
       // Tell Google Analytics that a user doesn't have location
-      ga('send', 'event', 'LocationFailure', 'PlanTripConsoller.$cordovaGeolocation.getCurrentPosition', 'location failed on Plan Trip; error: ' + err.msg);
+      ga('send', 'event', 'LocationFailure', 'PlanTripConsoller.$cordovaGeolocation.getCurrentPosition', 'location failed on Plan Trip; error: ' + err.message);
       // When getting location fails, this callback fires
       $scope.noLocation = true;
       /* When getting location fails immediately, $ionicLoading.hide()

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -327,6 +327,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       getStops(position);
     }, function (error) {
       getStops();
+      Map.showInsecureOriginLocationPopup(error);
       console.error('code: ' + error.code + '\n' +
         'message: ' + error.message + '\n');
       ga('send', 'event', 'LocationFailure',


### PR DESCRIPTION
Thanks to #267, users on `m.pvta.com` can't use access any of our features that require your current location.  This PR tries to help mitigate any people saying "why the *&@# doesn't this stupid thing work" by showing them a popup explaining that we've "temporarily disabled" getting their location.  This popup will appear when Cordova throws the specific error, which includes an int code and String message that we can check to be sure we actually need to display the popup.