### PR TITLE
Less loaders

### DIFF
--- a/www/app.js
+++ b/www/app.js
@@ -9,6 +9,11 @@ angular.module('pvta.factories', ['ngResource']);
 angular.module('pvta.directives', []);
 angular.module('pvta', ['ionic', 'ngCordova', 'pvta.controllers', 'angularMoment', 'jett.ionic.filter.bar', 'underscore', 'ionic-datepicker', 'ionic-timepicker', 'ngAnimate', 'ngAria'])
 
+.constant('ionicLoadingConfig', {
+  hideOnStateChange: true,
+  duration: 5000
+})
+
 .run(function ($ionicPlatform) {
   $ionicPlatform.ready(function () {
     // Hide the accessory bar by default (remove this to show the accessory bar above the keyboard

--- a/www/pages/plan-trip/plan-trip-controller.js
+++ b/www/pages/plan-trip/plan-trip-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('PlanTripController', function ($scope, $location, $state, $q, $cordovaGeolocation, $ionicLoading, $ionicPopup, $ionicScrollDelegate, NearestStop, Trips, $timeout, ionicDatePicker, ionicTimePicker, Map) {
+angular.module('pvta.controllers').controller('PlanTripController', function ($scope, $location, $state, $q, $cordovaGeolocation, $ionicLoading, $ionicPopup, $ionicScrollDelegate, NearestStop, Trips, $timeout, ionicDatePicker, ionicTimePicker, Map, ionicLoadingConfig) {
   ga('set', 'page', '/plan-trip.html');
   ga('send', 'pageview');
   defaultMapCenter = new google.maps.LatLng(42.3918143, -72.5291417);//Coords for UMass Campus Center
@@ -27,7 +27,7 @@ angular.module('pvta.controllers').controller('PlanTripController', function ($s
   var loadLocation = function () {
     var deferred = $q.defer();
     var options = {timeout: 5000, enableHighAccuracy: true};
-    $ionicLoading.show();
+    $ionicLoading.show(ionicLoadingConfig);
 
     $cordovaGeolocation.getCurrentPosition(options).then(function (position) {
       $ionicLoading.hide();
@@ -257,7 +257,8 @@ angular.module('pvta.controllers').controller('PlanTripController', function ($s
     }
 
     $ionicLoading.show({
-      template: 'Routing..'
+      template: 'Routing..',
+      timeout: 5000
     });
 
     transitOptions = {

--- a/www/pages/route-map/route-map-controller.js
+++ b/www/pages/route-map/route-map-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RouteMapController', function ($scope, $stateParams, $ionicLoading, Map, Route, $interval, RouteVehicles) {
+angular.module('pvta.controllers').controller('RouteMapController', function ($scope, $stateParams, $ionicLoading, Map, Route, $interval, RouteVehicles, ionicLoadingConfig) {
   ga('set', 'page', '/route-map.html');
   ga('send', 'pageview');
   var timer;
@@ -50,7 +50,7 @@ angular.module('pvta.controllers').controller('RouteMapController', function ($s
   }
 
   $scope.$on('$ionicView.enter', function () {
-    $ionicLoading.show({});
+    $ionicLoading.show(ionicLoadingConfig);
     Map.plotCurrentLocation();
     $scope.route = Route.get({routeId: $stateParams.routeId}, function () {
       $scope.stops = $scope.route.Stops;

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -349,7 +349,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     // Get the stops.
     getStops().then(function (stops) {
       $scope.stops = StopsForage.uniq(stops);
-      getFavoriteStops(stops);
+      getFavoriteStops($scope.stops);
       redraw();
       console.log(time.diff(moment()));
       // Grab the current location and sort by it

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -312,7 +312,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       $ionicLoading.show({
         template: msg,
         noBackdrop: true,
-        duration: (1500)
+        duration: 1500
       });
     }
   }
@@ -341,7 +341,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
   }
 
   $scope.$on('$ionicView.enter', function () {
-  //  $ionicLoading.show();
     time = moment();
     // Load the list of routes - do this every time
     // because we need to update the "heart" for each one.

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -51,6 +51,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       redraw();
     });
   }
+  var time;
   /*
    * Gets all the PVTA stops.
    */
@@ -60,6 +61,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       calculateStopDistances(position);
       getFavoriteStops(stops, position);
       redraw();
+      console.log(time.diff(moment(), 'seconds'));
       $ionicLoading.hide();
     });
   }
@@ -347,11 +349,14 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
 
   $scope.$on('$ionicView.enter', function () {
     $ionicLoading.show();
+    time = moment();
     // Load the list of routes - do this every time
     // because we need to update the "heart" for each one.
     getRoutes();
     // Grab the current location and get the stops.
     Map.getCurrentPosition().then(function (position) {
+      console.log(time.diff(moment(), 'seconds'));
+      time = moment();
       getStops(position);
     }, function (error) {
       getStops();

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -349,13 +349,14 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       $ionicLoading.hide();
       $scope.stops = StopsForage.uniq(stops);
       getFavoriteStops($scope.stops);
-      redraw();
       // Grab the current location
       Map.getCurrentPosition().then(function (position) {
         calculateStopDistances(position);
+        redraw();
       }, function (error) {
         Map.showInsecureOriginLocationPopup(error);
         calculateStopDistances();
+        redraw();
         // No location? Log and report.
         console.error('No location. Code: ' + error.code + '\n' +
           'message: ' + error.message + '\n');
@@ -364,6 +365,5 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
           'Location failed in RoutesAndStops; error: ' + error.code + ':, ' + error.message);
       });
     });
-    redraw();
   });
 });

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -51,7 +51,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       redraw();
     });
   }
-  var time;
   /*
    * Gets all the PVTA stops.
    */
@@ -341,7 +340,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
   }
 
   $scope.$on('$ionicView.enter', function () {
-    time = moment();
     // Load the list of routes - do this every time
     // because we need to update the "heart" for each one.
     getRoutes();
@@ -350,16 +348,13 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       $scope.stops = StopsForage.uniq(stops);
       getFavoriteStops($scope.stops);
       redraw();
-      console.log(time.diff(moment()));
-      // Grab the current location and sort by it
+      // Grab the current location
       Map.getCurrentPosition().then(function (position) {
-        console.log('pos ', time.diff(moment()));
         calculateStopDistances(position);
-        time = moment();
       }, function (error) {
-        console.log('pos', time.diff(moment()));
         Map.showInsecureOriginLocationPopup(error);
         calculateStopDistances();
+        // No location? Log and report.
         console.error('No location. Code: ' + error.code + '\n' +
           'message: ' + error.message + '\n');
         ga('send', 'event', 'LocationFailure',

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, $cordovaToast) {
+angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, $cordovaToast, ionicLoadingConfig) {
   ga('set', 'page', '/routes-and-stops.html');
   ga('send', 'pageview');
   // The two dimensions used in the view to sort the lists.
@@ -188,7 +188,7 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       // We use the haversine formula here because it's more accurate
       // the standard Distance Formula.
       if (!previousPosition || (previousPosition !== undefined && (haversine(previousPosition, currentPosition) > .1))) {
-        var msg = 'User has no previous position or has moved; calculating stop distances.';
+        var msg = 'Current position found, but no previous position or has moved; calculating stop distances.';
         ga('send', 'event', 'CalculatingStopDistances',
           'RoutesAndStopsController.calculateStopDistances', msg);
         console.log(msg);
@@ -342,9 +342,11 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
   $scope.$on('$ionicView.enter', function () {
     // Load the list of routes - do this every time
     // because we need to update the "heart" for each one.
+    $ionicLoading.show(ionicLoadingConfig);
     getRoutes();
     // Get the stops.
     getStops().then(function (stops) {
+      $ionicLoading.hide();
       $scope.stops = StopsForage.uniq(stops);
       getFavoriteStops($scope.stops);
       redraw();

--- a/www/pages/stop-map/stop-map-controller.js
+++ b/www/pages/stop-map/stop-map-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('StopMapController', function ($scope, $ionicLoading, $stateParams, $ionicHistory, $ionicPopup, Stop, Map) {
+angular.module('pvta.controllers').controller('StopMapController', function ($scope, $ionicLoading, $stateParams, $ionicHistory, $ionicPopup, Stop, Map, ionicLoadingConfig) {
   ga('set', 'page', '/stop-map.html');
   ga('send', 'pageview');
 
@@ -46,7 +46,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
    * to the stop in question and displays them on the UI.
   */
   $scope.calculateDirections = function () {
-    $ionicLoading.show({duration: 5000});
+    $ionicLoading.show(ionicLoadingConfig);
     // A callback that we pass to the plotCurrentLocation
     // function below.  Handles actually getting
     // and displaying directions once we have a location.
@@ -87,7 +87,7 @@ angular.module('pvta.controllers').controller('StopMapController', function ($sc
   };
 
   $scope.$on('$ionicView.enter', function () {
-    $ionicLoading.show({});
+    $ionicLoading.show(ionicLoadingConfig);
     // The map div can have one of two ids:
     // one when directions are being shown, the other when not.
     // Check which id the map has, pluck it from the HTML, and bind it

--- a/www/pages/stop/stop-controller.js
+++ b/www/pages/stop/stop-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('StopController', function ($scope, $stateParams, $interval, $state, Stop, StopDeparture, moment, FavoriteStops, SimpleRoute, $ionicLoading) {
+angular.module('pvta.controllers').controller('StopController', function ($scope, $stateParams, $interval, $state, Stop, StopDeparture, moment, FavoriteStops, SimpleRoute, $ionicLoading, ionicLoadingConfig) {
   ga('set', 'page', '/stop.html');
   ga('send', 'pageview');
   $scope.ROUTE_DIRECTION = '0';
@@ -136,7 +136,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
   }
 
   $scope.getDepartures = function () {
-    $ionicLoading.show();
+    $ionicLoading.show(ionicLoadingConfig);
     StopDeparture.query({ stopId: $stateParams.stopId }, function (deps) {
       if (deps) {
         // Avail returns a one element array that contains
@@ -174,7 +174,7 @@ angular.module('pvta.controllers').controller('StopController', function ($scope
    * localforage throws an error, set to 30s.
    ********************************************/
   $scope.$on('$ionicView.enter', function () {
-    $ionicLoading.show({});
+    $ionicLoading.show(ionicLoadingConfig);
     loadOrdering();
     getHeart();
     localforage.getItem('autoRefresh', function (err, value) {


### PR DESCRIPTION
Closes #289 by adding a timeout (never more than 5 seconds) to every loader in the app.

Also changes the order of how we load `Routes and Stops`.