### PR TITLE
Stop Modal Propogation Fix and Helper Factory Addition

### DIFF
--- a/www/factories/helper-factories.js
+++ b/www/factories/helper-factories.js
@@ -1,0 +1,17 @@
+angular.module('pvta.factories')
+
+.factory('Helper', function ($state) {
+
+  function redirectToStop (stopId) {
+    $state.go('app.stop', {stopId: stopId});
+  }
+
+  function redirectToRoute (routeId) {
+    $state.go('app.route', {routeId: routeId});
+  }
+
+  return {
+    redirectToStop: redirectToStop,
+    redirectToRoute: redirectToRoute
+  };
+});

--- a/www/index.html
+++ b/www/index.html
@@ -102,6 +102,7 @@
     <script src="factories/stop-list-factories.js"></script>
     <script src="factories/stops-forage-factories.js"></script>
     <script src="factories/trips-factories.js"></script>
+    <script src="factories/helper-factories.js"></script>
 
     <script src="directives/route/route-directive.js"></script>
     <script src="directives/vehicle/vehicle-directive.js"></script>

--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RouteController', function($scope, $state, $stateParams, $ionicLoading, Route, RouteVehicles, FavoriteRoutes, Messages, $location, $ionicScrollDelegate, $ionicModal, FavoriteStops, $ionicFilterBar){
+angular.module('pvta.controllers').controller('RouteController', function($scope, $state, $stateParams, $ionicLoading, Route, RouteVehicles, FavoriteRoutes, Messages, $location, $ionicScrollDelegate, $ionicModal, FavoriteStops, $ionicFilterBar, Helper){
   ga('set', 'page', '/route.html');
   ga('set', 'route', $stateParams.routeId);
   ga('send', 'pageview');
@@ -102,9 +102,7 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
     getVehicles();
   };
 
-  $scope.redirectToStop = function (stopId) {
-    $state.go('app.stop', {stopId: stopId});
-  };
+  $scope.redirectToStop = Helper.redirectToStop;
 
   $scope.$on('$ionicView.enter', function () {
     getHeart();

--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -102,6 +102,10 @@ angular.module('pvta.controllers').controller('RouteController', function($scope
     getVehicles();
   };
 
+  $scope.redirectToStop = function (stopId) {
+    $state.go('app.stop', {stopId: stopId});
+  };
+
   $scope.$on('$ionicView.enter', function () {
     getHeart();
   });

--- a/www/pages/route/stop-modal.html
+++ b/www/pages/route/stop-modal.html
@@ -5,7 +5,7 @@
     <button class="button button-icon icon ion-ios-search-strong" ng-click="showFilterBar()"></button>
   </ion-header-bar>
   <ion-content class="padding">
-    <ion-item ng-repeat="stop in stops | limitTo: 40" class= "item-icon-left item-icon-right" ng-click="stopModal.remove()" href="#/app/stops/{{stop.StopId}}">
+    <ion-item ng-repeat="stop in stops | limitTo: 40" class= "item-icon-left item-icon-right" ng-click="redirectToStop(stop.StopId); stopModal.remove()">
       <stop liked="stop.Liked" data="stop" toggle="toggleStopHeart"></stop>
     </ion-item>
   </ion-content>

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, $cordovaToast) {
+angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, $cordovaToast, Helper) {
   ga('set', 'page', '/routes-and-stops.html');
   ga('send', 'pageview');
   // The two dimensions used in the view to sort the lists.
@@ -32,13 +32,9 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
   *  more info about $event.stopPropagation())
   */
 
-  $scope.redirectRoute = function (routeId) {
-    $state.go('app.route', {routeId: routeId});
-  };
+  $scope.redirectRoute = Helper.redirectToRoute;
 
-  $scope.redirectStop = function (stopId) {
-    $state.go('app.stop', {stopId: stopId});
-  };
+  $scope.redirectStop = Helper.redirectToStop;
 
   /*
    * Gets all the PVTA routes.


### PR DESCRIPTION
Closes #296.  Removes a rogue `href` that was causing the issue.  Adds a `Helper Factory` that contains functions of general usefulness.  Populate with functions currently being used in R&S that would've needed to be copied into Route.