### PR TITLE
Fix localforage failures related to bad storage permissions

### DIFF
--- a/www/factories/favorite-routes-factories.js
+++ b/www/factories/favorite-routes-factories.js
@@ -31,7 +31,7 @@ angular.module('pvta.factories')
   };
 
   var remove = function (favoriteRoute) {
-    localforage.getItem('favoriteRoutes', function (err, favoriteRoutes) {
+    localforage.getItem('favoriteRoutes').then(function (favoriteRoutes) {
       for (var i = 0; i < favoriteRoutes.length; i++) {
         if (favoriteRoutes[i].RouteId === favoriteRoute.RouteId) {
           favoriteRoutes.splice(i, 1);
@@ -42,6 +42,9 @@ angular.module('pvta.factories')
           console.log('Error getting all favorite stops: ' + err);
         }
       });
+      Toast.show('Removed the ' + route.RouteAbbreviation + ' from your favorites!', 3000);
+    }).catch(function () {
+      Toast.show('Couldn\t unfavorite route.');
     });
   };
 

--- a/www/factories/favorite-routes-factories.js
+++ b/www/factories/favorite-routes-factories.js
@@ -1,6 +1,6 @@
 angular.module('pvta.factories')
 
-.factory('FavoriteRoutes', function () {
+.factory('FavoriteRoutes', function (Toast) {
   var push = function (route) {
     localforage.getItem('favoriteRoutes').then(function (err, favoriteRoutes) {
       var newRoute = {

--- a/www/factories/favorite-routes-factories.js
+++ b/www/factories/favorite-routes-factories.js
@@ -2,7 +2,7 @@ angular.module('pvta.factories')
 
 .factory('FavoriteRoutes', function (Toast) {
   var push = function (route) {
-    localforage.getItem('favoriteRoutes').then(function (err, favoriteRoutes) {
+    localforage.getItem('favoriteRoutes').then(function (favoriteRoutes) {
       var newRoute = {
         RouteId: route.RouteId,
         GoogleDescription: route.GoogleDescription,
@@ -29,22 +29,27 @@ angular.module('pvta.factories')
   var getAll = function () {
     return localforage.getItem('favoriteRoutes');
   };
-
+  // Removes a route from the user's Favorites.
+  // @param favoriteRoute - a Route object.
   var remove = function (favoriteRoute) {
+    // First, load the existing list of favorite routes.
     localforage.getItem('favoriteRoutes').then(function (favoriteRoutes) {
+      // Go through the list until we find the one we're trying to remove.
       for (var i = 0; i < favoriteRoutes.length; i++) {
         if (favoriteRoutes[i].RouteId === favoriteRoute.RouteId) {
           favoriteRoutes.splice(i, 1);
         }
       }
+      // Save the new list, which has the desired route removed.
       localforage.setItem('favoriteRoutes', favoriteRoutes, function (err) {
         if (err) {
-          console.log('Error getting all favorite stops: ' + err);
+          console.log('Error saving removed favorite route: ' + err);
         }
       });
-      Toast.show('Removed the ' + route.RouteAbbreviation + ' from your favorites!', 3000);
+      Toast.show('Removed the ' + favoriteRoute.RouteAbbreviation + ' from your favorites!', 3000);
+    // In the event that we can't load favorites, show an error.
     }).catch(function () {
-      Toast.show('Couldn\t unfavorite route.');
+      Toast.show('Couldn\'t unfavorite route.');
     });
   };
 

--- a/www/factories/favorite-routes-factories.js
+++ b/www/factories/favorite-routes-factories.js
@@ -2,7 +2,7 @@ angular.module('pvta.factories')
 
 .factory('FavoriteRoutes', function () {
   var push = function (route) {
-    localforage.getItem('favoriteRoutes', function (err, favoriteRoutes) {
+    localforage.getItem('favoriteRoutes').then(function (err, favoriteRoutes) {
       var newRoute = {
         RouteId: route.RouteId,
         GoogleDescription: route.GoogleDescription,
@@ -20,6 +20,9 @@ angular.module('pvta.factories')
         localforage.setItem('favoriteRoutes', newFavoriteRoute);
       }
       ga('send', 'event', 'FavoriteRouteAdded', 'FavoriteRoutes.push()', 'Favorited route with ID: ' + route.RouteId);
+      Toast.show('Added the ' + route.RouteAbbreviation + ' to your favorites!', 3000);
+    }).catch(function () {
+      Toast.show('Couldn\'t favorite route.', 2000);
     });
   };
 

--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -1,8 +1,8 @@
 angular.module('pvta.factories')
-.factory('FavoriteStops', function () {
+.factory('FavoriteStops', function (Toast) {
 
   var push = function (stop) {
-    localforage.getItem('favoriteStops', function (err, stops) {
+    localforage.getItem('favoriteStops').then(function (stops) {
       var newStop = {
         StopId: stop.StopId,
         Description: stop.Description
@@ -16,6 +16,9 @@ angular.module('pvta.factories')
         localforage.setItem('favoriteStops', favoriteStops);
       }
       ga('send', 'event', 'FavoriteStopAdded', 'FavoriteStops.push()', 'Favorited stop with ID: ' + stop.StopId);
+      Toast.show('Added ' + stop.Description + ' to your favorites!', 3000);
+    }).catch(function () {
+      Toast.show('Couldn\'t favorite stop', 2000);
     });
   };
 

--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -18,7 +18,7 @@ angular.module('pvta.factories')
       ga('send', 'event', 'FavoriteStopAdded', 'FavoriteStops.push()', 'Favorited stop with ID: ' + stop.StopId);
       Toast.show('Added ' + stop.Description + ' to your favorites!', 3000);
     }).catch(function () {
-      Toast.show('Couldn\'t favorite stop', 2000);
+      Toast.show('Couldn\'t favorite stop.', 2000);
     });
   };
 
@@ -27,7 +27,7 @@ angular.module('pvta.factories')
   };
 
   var remove = function (stop) {
-    localforage.getItem('favoriteStops', function (err, stops) {
+    localforage.getItem('favoriteStops').then(function (stops) {
       for (var i = 0; i < stops.length; i++) {
         if (stops[i].StopId === stop.StopId) {
           stops.splice(i, 1);
@@ -38,6 +38,9 @@ angular.module('pvta.factories')
           console.log('Error removing favorite stop: ' + err);
         }
       });
+      Toast.show('Removed ' + stop.Description + ' from your favorites!', 3000);
+    }).catch(function () {
+      Toast.show('Couldn\t unfavorite stop.');
     });
   };
 

--- a/www/factories/favorite-stops-factories.js
+++ b/www/factories/favorite-stops-factories.js
@@ -40,7 +40,7 @@ angular.module('pvta.factories')
       });
       Toast.show('Removed ' + stop.Description + ' from your favorites!', 3000);
     }).catch(function () {
-      Toast.show('Couldn\t unfavorite stop.');
+      Toast.show('Couldn\'t unfavorite stop.');
     });
   };
 

--- a/www/factories/helper-factories.js
+++ b/www/factories/helper-factories.js
@@ -18,24 +18,27 @@ angular.module('pvta.factories')
 
 angular.module('pvta.factories')
 
-.factory('Toast', function ($cordovaToast, $ionicLoading) {
+.factory('Toast', function ($cordovaToast, $ionicLoading, $interval) {
   // Shows a toast.
   // @param: duration - int. Can be 900, 2000, 3000, or 4000 due to a restriction in the
   // Cordova plugin.  Values are in milliseconds.
   function show (msg, duration) {
-    if (duration !== 900 && duration !== 2000 && duration !== 3000 && duration !== 4000) {
-      duration = 3000;
+    if ((duration !== 900) && (duration !== 2000) && (duration !== 3000) && (duration !== 4000)) {
       console.error('Toast.show() received an invalid parameter of ' + duration);
+      duration = 3000;
     }
     if (!ionic.Platform.is('browser')) {
       $cordovaToast.show(msg, duration, 'bottom');
     }
     else {
-      $ionicLoading.show({
-        template: msg,
-        noBackdrop: true,
-        duration: duration
-      });
+      $ionicLoading.hide();
+      $interval(function () {
+        $ionicLoading.show({
+          template: msg,
+          noBackdrop: true,
+          duration: duration
+        });
+      }, 500, 1);
     }
   }
 

--- a/www/factories/helper-factories.js
+++ b/www/factories/helper-factories.js
@@ -15,3 +15,31 @@ angular.module('pvta.factories')
     redirectToRoute: redirectToRoute
   };
 });
+
+angular.module('pvta.factories')
+
+.factory('Toast', function ($cordovaToast, $ionicLoading) {
+  // Shows a toast.
+  // @param: duration - int. Can be 900, 2000, 3000, or 4000 due to a restriction in the
+  // Cordova plugin.  Values are in milliseconds.
+  function show (msg, duration) {
+    if (duration !== 900 && duration !== 2000 && duration !== 3000 && duration !== 4000) {
+      duration = 3000;
+      console.error('Toast.show() received an invalid parameter of ' + duration);
+    }
+    if (!ionic.Platform.is('browser')) {
+      $cordovaToast.show(msg, duration, 'bottom');
+    }
+    else {
+      $ionicLoading.show({
+        template: msg,
+        noBackdrop: true,
+        duration: duration
+      });
+    }
+  }
+
+  return {
+    show: show,
+  };
+});

--- a/www/factories/helper-factories.js
+++ b/www/factories/helper-factories.js
@@ -41,8 +41,12 @@ angular.module('pvta.factories')
       }, 500, 1);
     }
   }
+  function showStorageError () {
+    Toast.show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
+  }
 
   return {
     show: show,
+    showStorageError: showStorageError
   };
 });

--- a/www/factories/helper-factories.js
+++ b/www/factories/helper-factories.js
@@ -28,7 +28,9 @@ angular.module('pvta.factories')
       duration = 3000;
     }
     if (!ionic.Platform.is('browser')) {
-      $cordovaToast.show(msg, duration, 'bottom');
+      $interval(function () {
+        $cordovaToast.show(msg, duration, 'bottom');
+      }, 500, 1);
     }
     else {
       $ionicLoading.hide();

--- a/www/factories/helper-factories.js
+++ b/www/factories/helper-factories.js
@@ -42,7 +42,7 @@ angular.module('pvta.factories')
     }
   }
   function showStorageError () {
-    Toast.show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
+    show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
   }
 
   return {

--- a/www/factories/route-forage-factories.js
+++ b/www/factories/route-forage-factories.js
@@ -1,6 +1,6 @@
 angular.module('pvta.factories')
 
-.factory('RouteForage', function (RouteList, moment, Recent, Routes, $q) {
+.factory('RouteForage', function (RouteList, moment, Recent, Routes, $q, Toast) {
   function getRouteList () {
     if (RouteList.isEmpty()) {
       return localforage.getItem('routes').then(function (routes) {
@@ -16,6 +16,9 @@ angular.module('pvta.factories')
           ga('send', 'event', 'RoutesNotLoaded', 'RouteForageFactory.getRouteList()', msg);
           return Routes.query().$promise;
         }
+      }).catch(function () {
+        Toast.show('Can\'t save routes. Ensure you\'re not in private browsing and that you allow us to store data.', 5000);
+        return Routes.query().$promise;
       });
     }
     else {

--- a/www/factories/route-forage-factories.js
+++ b/www/factories/route-forage-factories.js
@@ -17,7 +17,7 @@ angular.module('pvta.factories')
           return Routes.query().$promise;
         }
       }).catch(function () {
-        Toast.show('Can\'t access device storage. Ensure that you allow us to store data.', 3000);
+        Toast.showStorageError();
         return Routes.query().$promise;
       });
     }
@@ -45,7 +45,7 @@ angular.module('pvta.factories')
       if (err) {
         var msg = 'Unable to save routes; Localforage error: ' + err;
         console.error(msg);
-        Toast.show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
+        Toast.showStorageError();
         ga('send', 'event', 'UnableToSaveRoutes', 'RouteForageFactory.pushListToForage()', msg);
       }
       else {

--- a/www/factories/route-forage-factories.js
+++ b/www/factories/route-forage-factories.js
@@ -5,15 +5,15 @@ angular.module('pvta.factories')
     if (RouteList.isEmpty()) {
       return localforage.getItem('routes').then(function (routes) {
         if ((routes !== null) && (routes.list.length > 0) && (Recent.recent(routes.time))) {
-          var msg = 'Loaded routes from storage.';
-          console.log(msg);
-          ga('send', 'event', 'RoutesLoaded', 'RouteForageFactory.getRouteList()', msg);
+          var loadedMsg = 'Loaded routes from storage.';
+          console.log(loadedMsg);
+          ga('send', 'event', 'RoutesLoaded', 'RouteForageFactory.getRouteList()', loadedMsg);
           return routes.list;
         }
         else {
-          var msg = 'No routes stored or routelist is old';
-          console.log(msg);
-          ga('send', 'event', 'RoutesNotLoaded', 'RouteForageFactory.getRouteList()', msg);
+          var notLoadedMsg = 'No routes stored or routelist is old';
+          console.log(notLoadedMsg);
+          ga('send', 'event', 'RoutesNotLoaded', 'RouteForageFactory.getRouteList()', notLoadedMsg);
           return Routes.query().$promise;
         }
       }).catch(function () {
@@ -43,15 +43,15 @@ angular.module('pvta.factories')
     };
     localforage.setItem('routes', toForage, function (err) {
       if (err) {
-        var msg = 'Unable to save routes; Localforage error: ' + err;
-        console.error(msg);
+        var errorMsg = 'Unable to save routes; Localforage error: ' + err;
+        console.error(errorMsg);
         Toast.showStorageError();
-        ga('send', 'event', 'UnableToSaveRoutes', 'RouteForageFactory.pushListToForage()', msg);
+        ga('send', 'event', 'UnableToSaveRoutes', 'RouteForageFactory.pushListToForage()', errorMsg);
       }
       else {
-        var msg = 'Saved routes list.';
-        console.log(msg);
-        ga('send', 'event', 'SuccessfullySavedRoutes', 'RoutesForageFactory.pushListToForage()', msg);
+        var successMsg = 'Saved routes list.';
+        console.log(successMsg);
+        ga('send', 'event', 'SuccessfullySavedRoutes', 'RoutesForageFactory.pushListToForage()', successMsg);
       }
     });
   }

--- a/www/factories/route-forage-factories.js
+++ b/www/factories/route-forage-factories.js
@@ -17,7 +17,7 @@ angular.module('pvta.factories')
           return Routes.query().$promise;
         }
       }).catch(function () {
-        Toast.show('Can\'t save routes. Ensure you\'re not in private browsing and that you allow us to store data.', 5000);
+        Toast.show('Can\'t access device storage. Ensure that you allow us to store data.', 3000);
         return Routes.query().$promise;
       });
     }
@@ -45,6 +45,7 @@ angular.module('pvta.factories')
       if (err) {
         var msg = 'Unable to save routes; Localforage error: ' + err;
         console.error(msg);
+        Toast.show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
         ga('send', 'event', 'UnableToSaveRoutes', 'RouteForageFactory.pushListToForage()', msg);
       }
       else {

--- a/www/factories/stops-forage-factories.js
+++ b/www/factories/stops-forage-factories.js
@@ -22,9 +22,9 @@ angular.module('pvta.factories')
           return Stops.query().$promise;
         }
       }).catch(function () {
-        Toast.show('Can\'t save stops. Ensure you\'re not in private browsing and that you allow us to store data.', 5000);
+        Toast.show('Can\'t access device storage. Ensure that you allow us to store data.', 5000);
         return Stops.query().$promise;
-      });;
+      });
     }
     else {
       var msg = 'Stop list already loaded';
@@ -50,6 +50,7 @@ angular.module('pvta.factories')
       if (err) {
         var msg = 'Unable to save stops; Localforage error: ' + err;
         console.error(msg);
+        Toast.show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
         ga('send', 'event', 'UnableToSaveStops', 'StopsForageFactory.pushListToForage()', msg);
       }
       else {

--- a/www/factories/stops-forage-factories.js
+++ b/www/factories/stops-forage-factories.js
@@ -22,7 +22,7 @@ angular.module('pvta.factories')
           return Stops.query().$promise;
         }
       }).catch(function () {
-        Toast.show('Can\'t access device storage. Ensure that you allow us to store data.', 5000);
+        Toast.showStorageError();
         return Stops.query().$promise;
       });
     }
@@ -50,7 +50,7 @@ angular.module('pvta.factories')
       if (err) {
         var msg = 'Unable to save stops; Localforage error: ' + err;
         console.error(msg);
-        Toast.show('Can\'t access device storage. Ensure you\'re not in private browsing and that you allow us to store data.', 4000);
+        Toast.showStorageError();
         ga('send', 'event', 'UnableToSaveStops', 'StopsForageFactory.pushListToForage()', msg);
       }
       else {

--- a/www/factories/stops-forage-factories.js
+++ b/www/factories/stops-forage-factories.js
@@ -1,6 +1,6 @@
 angular.module('pvta.factories')
 
-.factory('StopsForage', function (StopList, Recent, Stops, NearestStops, $q) {
+.factory('StopsForage', function (StopList, Recent, Stops, NearestStops, $q, Toast) {
   function getStopList () {
     if (StopList.isEmpty()) {
       return localforage.getItem('stops').then(function (stops) {
@@ -21,7 +21,10 @@ angular.module('pvta.factories')
            */
           return Stops.query().$promise;
         }
-      });
+      }).catch(function () {
+        Toast.show('Can\'t save stops. Ensure you\'re not in private browsing and that you allow us to store data.', 5000);
+        return Stops.query().$promise;
+      });;
     }
     else {
       var msg = 'Stop list already loaded';

--- a/www/factories/stops-forage-factories.js
+++ b/www/factories/stops-forage-factories.js
@@ -5,15 +5,15 @@ angular.module('pvta.factories')
     if (StopList.isEmpty()) {
       return localforage.getItem('stops').then(function (stops) {
         if ((stops !== null) && (stops.list.length > 0) && (Recent.recent(stops.time))) {
-          var msg = 'Loaded stops from storage';
-          console.log(msg);
-          ga('send', 'event', 'StopsLoaded', 'StopsForageFactory.getStopList()', msg);
+          var loadedMsg = 'Loaded stops from storage';
+          console.log(loadedMsg);
+          ga('send', 'event', 'StopsLoaded', 'StopsForageFactory.getStopList()', loadedMsg);
           return stops.list;
         }
         else {
-          var msg = 'No stops stored or stoplist is old';
-          console.log(msg);
-          ga('send', 'event', 'StopsNotLoaded', 'StopsForageFactory.getStopList()', msg);
+          var notLoadedMsg = 'No stops stored or stoplist is old';
+          console.log(notLoadedMsg);
+          ga('send', 'event', 'StopsNotLoaded', 'StopsForageFactory.getStopList()', notLoadedMsg);
           /* Grab the current position.
            * If we get it, get the list of stops based on that.
            * Otherwise, just get a list of stops.  Avail's purview
@@ -48,15 +48,15 @@ angular.module('pvta.factories')
     };
     localforage.setItem('stops', toForage, function (err) {
       if (err) {
-        var msg = 'Unable to save stops; Localforage error: ' + err;
-        console.error(msg);
+        var errorMsg = 'Unable to save stops; Localforage error: ' + err;
+        console.error(errorMsg);
         Toast.showStorageError();
-        ga('send', 'event', 'UnableToSaveStops', 'StopsForageFactory.pushListToForage()', msg);
+        ga('send', 'event', 'UnableToSaveStops', 'StopsForageFactory.pushListToForage()', errorMsg);
       }
       else {
-        var msg = 'Saved stops list.';
-        console.log(msg);
-        ga('send', 'event', 'SuccessfullySavedStops', 'StopsForageFactory.pushListToForage()', msg);
+        var successMsg = 'Saved stops list.';
+        console.log(successMsg);
+        ga('send', 'event', 'SuccessfullySavedStops', 'StopsForageFactory.pushListToForage()', successMsg);
       }
     });
   }

--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -60,7 +60,7 @@ angular.module('pvta.controllers').controller('RouteController', function ($scop
         $scope.stops.push({StopId: stop.StopId, Description: stop.Description, Liked: liked});
       }
     }).catch(function () {
-      Toast.show('Can\'t access device storage. Ensure that you allow us to store data.', 3000);
+      Toast.showStorageError();
       $scope.stops = stops;
     });
   }

--- a/www/pages/route/route-controller.js
+++ b/www/pages/route/route-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RouteController', function ($scope, $state, $stateParams, $ionicLoading, Route, RouteVehicles, FavoriteRoutes, Messages, $location, $ionicScrollDelegate, $ionicModal, FavoriteStops, $ionicFilterBar, Helper) {
+angular.module('pvta.controllers').controller('RouteController', function ($scope, $state, $stateParams, $ionicLoading, Route, RouteVehicles, FavoriteRoutes, Messages, $location, $ionicScrollDelegate, $ionicModal, FavoriteStops, $ionicFilterBar, Helper, Toast) {
   ga('set', 'page', '/route.html');
   ga('set', 'route', $stateParams.routeId);
   ga('send', 'pageview');
@@ -59,6 +59,9 @@ angular.module('pvta.controllers').controller('RouteController', function ($scop
         }
         $scope.stops.push({StopId: stop.StopId, Description: stop.Description, Liked: liked});
       }
+    }).catch(function () {
+      Toast.show('Can\'t access device storage. Ensure that you allow us to store data.', 3000);
+      $scope.stops = stops;
     });
   }
   /**

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, Helper, ionicLoadingConfig, Toast) {
+angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, Helper, ionicLoadingConfig) {
   ga('set', 'page', '/routes-and-stops.html');
   ga('send', 'pageview');
   // The two dimensions used in the view to sort the lists.

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -321,7 +321,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     FavoriteRoutes.contains(route, function (bool) {
       if (bool) {
         FavoriteRoutes.remove(route);
-        Toast.show('Removed the ' + route.RouteAbbreviation + ' from your favorites!', 3000);
       }
       else {
         FavoriteRoutes.push(route);

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -1,4 +1,4 @@
-angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, $cordovaToast, Helper, ionicLoadingConfig) {
+angular.module('pvta.controllers').controller('RoutesAndStopsController', function ($scope, $ionicFilterBar, $cordovaGeolocation, RouteForage, StopsForage, $ionicLoading, $stateParams, $state, FavoriteStops, FavoriteRoutes, Map, Helper, ionicLoadingConfig, Toast) {
   ga('set', 'page', '/routes-and-stops.html');
   ga('send', 'pageview');
   // The two dimensions used in the view to sort the lists.
@@ -304,28 +304,15 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     FavoriteStops.contains(stop.StopId, function (bool) {
       if (bool) {
         FavoriteStops.remove(stop);
-        showToast('Removed ' + stop.Description + ' from your favorites!');
+        Toast.show('Removed ' + stop.Description + ' from your favorites!', 3000);
       }
       else {
         FavoriteStops.push(stop);
-        showToast('Added ' + stop.Description + ' to your favorites!');
+        Toast.show('Added ' + stop.Description + ' to your favorites!', 3000);
       }
       $scope.$apply();
     });
   };
-
-  function showToast (msg) {
-    if (!ionic.Platform.is('browser')) {
-      $cordovaToast.showLongBottom(msg);
-    }
-    else {
-      $ionicLoading.show({
-        template: msg,
-        noBackdrop: true,
-        duration: 1500
-      });
-    }
-  }
 
   /*
    * Called when a user clicks on the heart button,
@@ -336,11 +323,11 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     FavoriteRoutes.contains(route, function (bool) {
       if (bool) {
         FavoriteRoutes.remove(route);
-        showToast('Removed the ' + route.RouteAbbreviation + ' from your favorites!');
+        Toast.show('Removed the ' + route.RouteAbbreviation + ' from your favorites!', 3000);
       }
       else {
         FavoriteRoutes.push(route);
-        showToast('Added the ' + route.RouteAbbreviation + ' to your favorites!');
+        Toast.show('Added the ' + route.RouteAbbreviation + ' to your favorites!', 3000);
       }
       $scope.$apply();
     });

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -304,7 +304,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
     FavoriteStops.contains(stop.StopId, function (bool) {
       if (bool) {
         FavoriteStops.remove(stop);
-        Toast.show('Removed ' + stop.Description + ' from your favorites!', 3000);
       }
       else {
         FavoriteStops.push(stop);

--- a/www/pages/routes-and-stops/routes-and-stops-controller.js
+++ b/www/pages/routes-and-stops/routes-and-stops-controller.js
@@ -308,7 +308,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       }
       else {
         FavoriteStops.push(stop);
-        Toast.show('Added ' + stop.Description + ' to your favorites!', 3000);
       }
       $scope.$apply();
     });
@@ -327,7 +326,6 @@ angular.module('pvta.controllers').controller('RoutesAndStopsController', functi
       }
       else {
         FavoriteRoutes.push(route);
-        Toast.show('Added the ' + route.RouteAbbreviation + ' to your favorites!', 3000);
       }
       $scope.$apply();
     });


### PR DESCRIPTION
Closes #304.  Localforage is the "gatekeeper" to retrieving and displaying Routes and Stops lists.

In private browsing (Safari and mobile Safari only) **and** in any browser that doesn't allow us storage permission, an improperly handled localforage error may cause the lists to never appear, rendering the app essentially useless.

This PR includes some factory functions for displaying error messages ("Toasts").  I've also changed some of the localforage methods from `callback` style to `ES6-promise` style.