### PR TITLE
Only Refresh Lists Once Per Session

### DIFF
--- a/src/modals/route-modal/route.modal.ts
+++ b/src/modals/route-modal/route.modal.ts
@@ -31,8 +31,7 @@ export class RouteModal {
     if (this.requester === RouteModalRequester.MyBuses) {
       let loader = this.loadingCtrl.create();
       loader.present();
-      this.routeService.getRouteList((routesPromise: Promise<Route[]>) => {
-        routesPromise.then(routes => {
+      this.routeService.getRouteList().then((routes: Route[]) => {
           console.log('have routes');
           this.routes = _.sortBy(routes, ['ShortName']);
           this.routeService.saveRouteList(this.routes);
@@ -41,7 +40,6 @@ export class RouteModal {
         }).catch(err => {
           console.error(err);
         })
-      });
     }
   }
 

--- a/src/modals/route-modal/route.modal.ts
+++ b/src/modals/route-modal/route.modal.ts
@@ -32,14 +32,14 @@ export class RouteModal {
       let loader = this.loadingCtrl.create();
       loader.present();
       this.routeService.getRouteList().then((routes: Route[]) => {
-          console.log('have routes');
-          this.routes = _.sortBy(routes, ['ShortName']);
-          this.routeService.saveRouteList(this.routes);
-          this.getFavoriteRoutes();
-          loader.dismiss();
-        }).catch(err => {
-          console.error(err);
-        })
+        console.log('have routes');
+        this.routes = _.sortBy(routes, ['ShortName']);
+        this.routeService.saveRouteList(this.routes);
+        this.getFavoriteRoutes();
+        loader.dismiss();
+      }).catch(err => {
+        console.error(err);
+      });
     }
   }
 

--- a/src/modals/stop-modal/stop.modal.ts
+++ b/src/modals/stop-modal/stop.modal.ts
@@ -60,13 +60,11 @@ export class StopModal {
     if (this.requester === StopModalRequester.MyBuses) {
       let loader = this.loadingCtrl.create();
       loader.present();
-      this.stopService.getStopList((stopsPromise: Promise<Stop[]>) => {
-        stopsPromise.then(stops => {
-          this.stops = _.uniqBy(stops, 'StopId');
-          this.stopService.saveStopList(this.stops);
-          this.getFavoriteStops();
-          loader.dismiss();
-        });
+      this.stopService.getStopList().then((stops: Stop[]) => {
+        this.stops = _.uniqBy(stops, 'StopId');
+        this.stopService.saveStopList(this.stops);
+        this.getFavoriteStops();
+        loader.dismiss();
       });
     }
   }

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -170,12 +170,8 @@ export class RoutesAndStopsComponent {
 
   ionViewWillEnter() {
     this.onSearchQueryChanged(this.searchQuery);
-
-
     let fs: Promise<any> = this.getfavStops();
     let fr: Promise<any> = this.getfavRoutes();
-
-
     Promise.all([this.routesPromise, fr]).then((value) => {
       console.log('ready with routes and fav routes', value);
       this.favRoutes = value[1];

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -141,29 +141,26 @@ export class RoutesAndStopsComponent {
   ionViewWillEnter() {
     this.onSearchQueryChanged(this.searchQuery);
     this.routeService.getRouteList().then((routes: Route[]) => {
-      // console.log(routes)
-        this.routes = _.sortBy(routes, ['ShortName']);
-        this.routesDisp = this.routes;
-        this.routeService.saveRouteList(this.routes);
-        this.getFavoriteRoutes();
+      this.routes = _.sortBy(routes, ['ShortName']);
+      this.routesDisp = this.routes;
+      this.routeService.saveRouteList(this.routes);
+      this.getFavoriteRoutes();
+    }).catch(err => {
+      console.error(err);
+    });
+    this.stopService.getStopList().then((stops: Stop[]) => {
+      this.stops = _.uniqBy(stops, 'StopId');
+      this.stopsDisp = this.stops;
+      this.stopService.saveStopList(this.stops);
+      this.getFavoriteStops();
+      let options = {timeout: 5000, enableHighAccuracy: true};
+      Geolocation.getCurrentPosition(options).then(position => {
+        this.calculateStopDistances(position)
       }).catch(err => {
-        console.error(err);
-      });
-    this.stopService.getStopList((stopsPromise: Promise<Stop[]>) => {
-      stopsPromise.then(stops => {
-        this.stops = _.uniqBy(stops, 'StopId');
-        this.stopsDisp = this.stops;
-        this.stopService.saveStopList(this.stops);
-        this.getFavoriteStops();
-        let options = {timeout: 5000, enableHighAccuracy: true};
-        Geolocation.getCurrentPosition(options).then(position => {
-          this.calculateStopDistances(position)
-        }).catch(err => {
-          this.calculateStopDistances()
-        })
-      }).catch(err => {
-        console.error(err);
-      });
+        this.calculateStopDistances()
+      })
+    }).catch(err => {
+      console.error(err);
     });
   }
   /*

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -95,7 +95,7 @@ export class RoutesAndStopsComponent {
   prepareRoutes(): any {
     // For each route, add the custom 'Liked' property and keep only
     // the properties we care about.  Doing this makes searching easier.
-    this.routes = <Route[]> _.map(this.routes, (route) => {
+    return _.map(this.routes, (route) => {
       route.Liked = _.includes(_.map(this.favoriteRoutes, 'RouteId'), route.RouteId);
       return _.pick(route, 'RouteId', 'RouteAbbreviation', 'LongName', 'ShortName', 'Color', 'GoogleDescription', 'Liked');
     });
@@ -153,19 +153,18 @@ export class RoutesAndStopsComponent {
     }).catch(err => {
       console.error(err);
     });
-    Promise.all([r, fr]).then(() => {
-      console.log('ready with routes and fav routes');
+    Promise.all([r, fr]).then((value) => {
+      console.log('ready with routes and fav routes', value);
+      this.favoriteRoutes = value[1];
       this.routes = this.prepareRoutes();
     });
-    Promise.all([s, fs]).then(() => {
-      console.log('ready with stops and fav stops');
-      this.routes = this.prepareRoutes();
+    Promise.all([s, fs]).then((value) => {
+      console.log('ready with stops and fav stops', value);
+      this.favoriteStops = value[1];
+      this.stops = this.prepareStops();
     });
-    fs.then(stops => {
-      this.favoriteStops = stops;
-    });
-    fr.then(routes => {
-      this.favoriteRoutes = routes;
+    Promise.all([r, fr, s, fs]).then(()=> {
+      this.toggleOrdering();
     });
     s.then((stops: Stop[]) => {
       this.stops = _.uniqBy(stops, 'StopId');

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -140,16 +140,15 @@ export class RoutesAndStopsComponent {
 
   ionViewWillEnter() {
     this.onSearchQueryChanged(this.searchQuery);
-    this.routeService.getRouteList((routesPromise: Promise<Route[]>) => {
-      routesPromise.then(routes => {
+    this.routeService.getRouteList().then((routes: Route[]) => {
+      // console.log(routes)
         this.routes = _.sortBy(routes, ['ShortName']);
         this.routesDisp = this.routes;
         this.routeService.saveRouteList(this.routes);
         this.getFavoriteRoutes();
       }).catch(err => {
         console.error(err);
-      })
-    });
+      });
     this.stopService.getStopList((stopsPromise: Promise<Stop[]>) => {
       stopsPromise.then(stops => {
         this.stops = _.uniqBy(stops, 'StopId');

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -139,7 +139,6 @@ export class RoutesAndStopsComponent {
   ionViewDidLoad() {
     this.routesPromise = this.routeSvc.getRouteList();
     this.routesPromise.then((routes: Route[]) => {
-      console.log('got a list of routes');
       this.routes = _.sortBy(routes, ['ShortName']);
       this.routesDisp = this.routes;
       this.routeSvc.saveRouteList(this.routes);
@@ -149,7 +148,6 @@ export class RoutesAndStopsComponent {
 
     this.stopsPromise = this.stopSvc.getStopList();
     this.stopsPromise.then((stops: Stop[]) => {
-      console.log('got a list of stops');
       this.stops = _.uniqBy(stops, 'StopId');
       this.stopsDisp = this.stops;
       this.stopSvc.saveStopList(this.stops);
@@ -170,12 +168,12 @@ export class RoutesAndStopsComponent {
     let fs: Promise<any> = this.getfavStops();
     let fr: Promise<any> = this.getfavRoutes();
     Promise.all([this.routesPromise, fr]).then((value) => {
-      console.log('ready with routes and fav routes');
+      console.log('Ready with routes and fav routes');
       this.favRoutes = value[1];
       this.routes = this.prepareRoutes();
     });
     Promise.all([this.stopsPromise, fs]).then((value) => {
-      console.log('ready with stops and fav stops');
+      console.log('Ready with stops and fav stops');
       this.favStops = value[1];
       this.stops = this.prepareStops();
     });

--- a/src/pages/routes-and-stops/routes-and-stops.html
+++ b/src/pages/routes-and-stops/routes-and-stops.html
@@ -30,6 +30,7 @@
 </ion-header>
 
 <ion-content padding>
+  {{routes | json}}
   <div [ngSwitch]="cDisplay">
     <ion-list text-wrap *ngSwitchCase="'routes'">
       <div ion-item *ngFor="let route of routesDisp"

--- a/src/pages/routes-and-stops/routes-and-stops.html
+++ b/src/pages/routes-and-stops/routes-and-stops.html
@@ -28,9 +28,7 @@
     </ion-select>
   </ion-item>
 </ion-header>
-
 <ion-content padding>
-  {{routes | json}}
   <div [ngSwitch]="cDisplay">
     <ion-list text-wrap *ngSwitchCase="'routes'">
       <div ion-item *ngFor="let route of routesDisp"

--- a/src/providers/route.service.ts
+++ b/src/providers/route.service.ts
@@ -51,11 +51,11 @@ export class RouteService {
     console.error('An error occurred', error); // for demo purposes only
   }
 
-  getRouteList (cb: Function): void {
+  getRouteList(): Promise<any> {
     console.log('getroutelist top');
-    this.storage.ready().then(() => {
+    return this.storage.ready().then(() => {
       console.log('getroutelist storage ready');
-      this.storage.get('routes').then((routes) => {
+      return this.storage.get('routes').then((routes) => {
         console.log('getroutelist list retrieved');
         if (routes && routes.list.length > 0) {
           console.log('list length > 0 and it exists');
@@ -64,17 +64,17 @@ export class RouteService {
           // console.log('the diference is', diff);
           if (diff <= 1) {
             console.log('Routeservice forage, returning list');
-            cb(new Promise((resolve, reject) => {
+            return new Promise((resolve, reject) => {
               resolve(routes.list);
-            }))
+            });
           } else {
             console.log('Routeservice forage, list is too old!');
-            cb(this.getAllRoutes());
+            return this.getAllRoutes();
           }
         }
         else {
           console.log('Routeservice forage, download routes');
-          cb(this.getAllRoutes());
+          return this.getAllRoutes();
         }
       }).catch(err => {
         console.error('an error getting routes from storage!', err);

--- a/src/providers/route.service.ts
+++ b/src/providers/route.service.ts
@@ -69,12 +69,12 @@ export class RouteService {
             });
           } else {
             console.log('Routeservice forage, list is too old!');
-            return this.getAllRoutes();
+            return Promise.resolve(this.getAllRoutes());
           }
         }
         else {
           console.log('Routeservice forage, download routes');
-          return this.getAllRoutes();
+          return Promise.resolve(this.getAllRoutes());
         }
       }).catch(err => {
         console.error('an error getting routes from storage!', err);

--- a/src/providers/stop.service.ts
+++ b/src/providers/stop.service.ts
@@ -40,25 +40,25 @@ export class StopService {
     console.error('An error occurred', error); // for demo purposes only
   }
 
-  getStopList (cb: Function): void {
-    this.storage.ready().then(() => {
-      this.storage.get('stops').then((stops) => {
+  getStopList (): Promise<any> {
+    return this.storage.ready().then(() => {
+      return this.storage.get('stops').then((stops) => {
         if (stops && stops.list.length > 0) {
           let now = moment();
           let diff = now.diff(stops.time, 'days')
           if (diff <= 1) {
             console.log('stoplist is loaded and recent')
-            cb(new Promise((resolve, reject) => {
+            return new Promise((resolve, reject) => {
               resolve(stops.list);
-            }))
+            });
           } else {
             console.log('stop list is too old!')
-            cb(this.getAllStops());
+            return this.getAllStops();
           }
         }
         else {
           console.log('got to download stops')
-          cb(this.getAllStops());
+          return this.getAllStops();
         }
       })
     });


### PR DESCRIPTION
Changes how promises are used in `Routes and Stops` and the `Route`/`Stop Service`s. No longer gets the lists and favorites each time the user navigates to `Routes and Stops`; now, it gets the lists once (they can be taxing, so best to do them less), and gets the favorites every time.

Continuing to get favorites each time is important for UX because a user can favorite a Route after they've already been to `Routes and Stops` and subsequently return to `R&S`; it must show they they've favorited it!

Closes #339.