### PR TITLE
"Adjust" Support for Internet Explorer [v2]

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,6 +7,7 @@ import { PlanTripComponent } from '../pages/plan-trip/plan-trip.component';
 import { RoutesAndStopsComponent } from '../pages/routes-and-stops/routes-and-stops.component';
 import { SettingsComponent } from '../pages/settings/settings.component';
 import { ConnectivityService } from '../providers/connectivity.service';
+import { InfoService } from '../providers/info.service';
 
 
 @Component({
@@ -20,7 +21,7 @@ export class MyApp {
   pages: Array<{title: string, component: any}>;
   showNativeStoreAd = false;
 
-  constructor(public platform: Platform,
+  constructor(public platform: Platform, private infoSvc: InfoService,
   private connectivityService: ConnectivityService) {
     this.initializeApp();
 
@@ -42,6 +43,8 @@ export class MyApp {
       if (this.platform.is('android')) {
         StatusBar.backgroundColorByHexString('#1976D2');
       }
+      let isIE: boolean = navigator.userAgent.indexOf('Trident', 0) !== -1;
+      this.infoSvc.setInternetExplorer(isIE);
       this.showNativeStoreAd = this.platform.is('mobileweb') || this.platform.is('core');
       Splashscreen.hide();
       window.addEventListener('online', () =>  {

--- a/src/pages/my-buses/my-buses.component.ts
+++ b/src/pages/my-buses/my-buses.component.ts
@@ -70,7 +70,7 @@ export class MyBusesComponent {
           this.alerts.push(alert);
         } else {
           for (let routeId of alert.Routes) {
-            if (routeIds.includes(routeId)) {
+            if (_.includes(routeIds, routeId)) {
               this.alerts.push(alert);
             }
           }

--- a/src/pages/plan-trip/plan-trip.component.ts
+++ b/src/pages/plan-trip/plan-trip.component.ts
@@ -35,6 +35,7 @@ export class PlanTripComponent {
    timeOptions = [];
    noLocationToast;
    noOriginOrDestinationToast;
+   isInternetExplorer: boolean = false;
 
   constructor(public navCtrl: NavController, private stopService: StopService,
   private toastCtrl: ToastController, private loadingCtrl: LoadingController,
@@ -46,6 +47,7 @@ export class PlanTripComponent {
      * isASAP: whether we should ignore all other given times and
                request a trip leaving NOW
       */
+    this.isInternetExplorer = navigator.userAgent.indexOf('Trident', 0) !== -1;
     this.timeOptions = [
       { title: 'Leaving Now', type: 'departure', isASAP: true, id: 0 },
       { title: 'Departing At...', type: 'departure', isASAP: false, id: 1 },

--- a/src/pages/plan-trip/plan-trip.component.ts
+++ b/src/pages/plan-trip/plan-trip.component.ts
@@ -1,9 +1,10 @@
 import { Component, ViewChild, ElementRef } from '@angular/core';
 import { Geolocation } from 'ionic-native';
 import { NavController, ToastController, LoadingController, AlertController, NavParams } from 'ionic-angular';
-import {StopService} from '../../providers/stop.service';
-import {FavoriteTripService} from '../../providers/favorite-trip.service';
-import {StopComponent} from '../stop/stop.component';
+import { StopService } from '../../providers/stop.service';
+import { FavoriteTripService } from '../../providers/favorite-trip.service';
+import { InfoService } from '../../providers/info.service';
+import { StopComponent } from '../stop/stop.component';
 import * as moment from 'moment';
 
 // @TODO THIS ENTIRE COMPONENT IS A WORK IN PROGRESS; #ALPHA
@@ -40,14 +41,14 @@ export class PlanTripComponent {
   constructor(public navCtrl: NavController, private stopService: StopService,
   private toastCtrl: ToastController, private loadingCtrl: LoadingController,
   private alertCtrl: AlertController, private tripService: FavoriteTripService,
-  private navParams: NavParams) {
+  private navParams: NavParams, private infoSvc: InfoService) {
     /* List of the different types of times that we can request trips.
      * Each type has a name (for the UI) and a few properties for us:
      * type: whether the user wants a "departure" or "arrival"
      * isASAP: whether we should ignore all other given times and
                request a trip leaving NOW
       */
-    this.isInternetExplorer = navigator.userAgent.indexOf('Trident', 0) !== -1;
+    this.isInternetExplorer = this.infoSvc.isInternetExplorer();
     this.timeOptions = [
       { title: 'Leaving Now', type: 'departure', isASAP: true, id: 0 },
       { title: 'Departing At...', type: 'departure', isASAP: false, id: 1 },

--- a/src/pages/plan-trip/plan-trip.html
+++ b/src/pages/plan-trip/plan-trip.html
@@ -31,7 +31,10 @@
       </label>
     </ion-item>
     <ion-item *ngIf="isInternetExplorer">
-      <p style="font-style: italic;">Internet Explorer only supports finding buses leaving now.</p>
+      <p style="font-style: italic;">
+        Internet Explorer does not support searching the schedule on
+        specific dates and times, and will only find the soonest available trip.
+      </p>
     </ion-item>
     <ion-item *ngIf="!isInternetExplorer">
       <ion-label>Search for buses:</ion-label>

--- a/src/pages/plan-trip/plan-trip.html
+++ b/src/pages/plan-trip/plan-trip.html
@@ -30,7 +30,10 @@
         type="text" placeholder="Enter a destination" [(ngModel)]="request?.destination.name"/>
       </label>
     </ion-item>
-    <ion-item>
+    <ion-item *ngIf="isInternetExplorer">
+      <p style="font-style: italic;">Internet Explorer only supports finding buses leaving now.</p>
+    </ion-item>
+    <ion-item *ngIf="!isInternetExplorer">
       <ion-label>Search for buses:</ion-label>
       <ion-select [(ngModel)]="request?.time.option">
         <ion-option *ngFor="let option of timeOptions" value="{{option.id}}">

--- a/src/pages/route/route.component.ts
+++ b/src/pages/route/route.component.ts
@@ -12,6 +12,7 @@ import { Stop } from '../../models/stop.model';
 import { RouteMapComponent } from '../route-map/route-map.component';
 import { StopModal, StopModalRequester } from '../../modals/stop-modal/stop.modal';
 import { ConnectivityService } from '../../providers/connectivity.service';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'page-route',
@@ -50,8 +51,7 @@ export class RouteComponent {
         return;
       }
       for (let alert of alerts) {
-        console.log(alert.Routes.includes(this.routeId));
-        if (alert.Routes.includes(this.routeId)) {
+        if (_.includes(alert.Routes, this.routeId)) {
           this.alerts.push(alert);
         }
       }

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -4,6 +4,7 @@ import { Storage } from '@ionic/storage';
 import {Geolocation} from 'ionic-native';
 import { RouteService } from '../../providers/route.service';
 import { StopService } from '../../providers/stop.service';
+import { InfoService } from '../../providers/info.service';
 import { FavoriteRouteService, FavoriteRouteModel } from '../../providers/favorite-route.service';
 import { Route } from '../../models/route.model';
 import { Stop } from '../../models/stop.model';
@@ -34,12 +35,12 @@ export class RoutesAndStopsComponent {
   routesPromise: Promise<any>;
   loader;
   isInternetExplorer: boolean = false;
-  constructor(public navCtrl: NavController,
+  constructor(public navCtrl: NavController, private infoSvc: InfoService,
     private routeSvc: RouteService, private stopSvc: StopService,
     private loadingCtrl: LoadingController, private storage: Storage,
     private favRouteSvc: FavoriteRouteService, private alertCtrl: AlertController,
     private favStopSvc: FavoriteStopService) {
-      this.isInternetExplorer = navigator.userAgent.indexOf('Trident', 0) !== -1;
+      this.isInternetExplorer = infoSvc.isInternetExplorer();
       this.order = 'favorites';
       this.cDisplay = 'routes';
       this.loader = loadingCtrl.create({

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -202,7 +202,7 @@ export class RoutesAndStopsComponent {
     let secondarySortType: string;
     // If routes are currently in view
     if (this.cDisplay === 'routes') {
-      if (!routeOrderings.includes(this.order)) {
+      if (!_.includes(routeOrderings, this.order)) {
         this.order = routeOrderings[0];
       }
       // Based on the user's requested ordering, we need to
@@ -226,7 +226,7 @@ export class RoutesAndStopsComponent {
         [primarySort, secondarySort], [primarySortType, secondarySortType]);
     } else if (this.cDisplay === 'stops') {
       // If stops are currently in view
-      if (!stopOrderings.includes(this.order)) {
+      if (!_.includes(stopOrderings, this.order)) {
         this.order = stopOrderings[0];
       }
       switch (this.order) {

--- a/src/pages/routes-and-stops/routes-and-stops.component.ts
+++ b/src/pages/routes-and-stops/routes-and-stops.component.ts
@@ -33,11 +33,13 @@ export class RoutesAndStopsComponent {
   stopsPromise: Promise<any>;
   routesPromise: Promise<any>;
   loader;
+  isInternetExplorer: boolean = false;
   constructor(public navCtrl: NavController,
     private routeSvc: RouteService, private stopSvc: StopService,
     private loadingCtrl: LoadingController, private storage: Storage,
     private favRouteSvc: FavoriteRouteService, private alertCtrl: AlertController,
     private favStopSvc: FavoriteStopService) {
+      this.isInternetExplorer = navigator.userAgent.indexOf('Trident', 0) !== -1;
       this.order = 'favorites';
       this.cDisplay = 'routes';
       this.loader = loadingCtrl.create({

--- a/src/pages/routes-and-stops/routes-and-stops.html
+++ b/src/pages/routes-and-stops/routes-and-stops.html
@@ -19,7 +19,7 @@
     (ionInput)="onSearchQueryChanged($event.target.value)">
     <!-- (ionCancel)="onCancel($event)"> -->
   </ion-searchbar>
-  <ion-item>
+  <ion-item *ngIf="!isInternetExplorer">
     <ion-label>Order {{cDisplay == 'routes' ? 'Routes' : 'Stops'}} By:</ion-label>
     <ion-select [(ngModel)]="order" (ionChange)="toggleOrdering()">
       <ion-option value="favorites">Favorites</ion-option>

--- a/src/pages/settings/settings.component.ts
+++ b/src/pages/settings/settings.component.ts
@@ -4,6 +4,7 @@ import { NavController } from 'ionic-angular';
 import { AboutComponent } from '../about/about.component';
 import { ContactComponent} from '../contact/contact.component';
 import { StorageSettingsComponent} from '../storage-settings/storage-settings.component';
+import { InfoService } from '../../providers/info.service';
 
 @Component({
   selector: 'page-settings',
@@ -12,8 +13,9 @@ import { StorageSettingsComponent} from '../storage-settings/storage-settings.co
 export class SettingsComponent {
   autoRefresh: string;
   isInternetExplorer: boolean = false;
-  constructor(public navCtrl: NavController, private storage: Storage) {
-    this.isInternetExplorer = navigator.userAgent.indexOf('Trident', 0) !== -1;
+  constructor(public navCtrl: NavController, private storage: Storage,
+  private infoSvc: InfoService) {
+    this.isInternetExplorer = infoSvc.isInternetExplorer();
     storage.ready().then(() => {
       storage.get('autoRefresh').then(autoRefreshTiming => {
         if (autoRefreshTiming) {

--- a/src/pages/settings/settings.component.ts
+++ b/src/pages/settings/settings.component.ts
@@ -11,7 +11,9 @@ import { StorageSettingsComponent} from '../storage-settings/storage-settings.co
 })
 export class SettingsComponent {
   autoRefresh: string;
+  isInternetExplorer: boolean = false;
   constructor(public navCtrl: NavController, private storage: Storage) {
+    this.isInternetExplorer = navigator.userAgent.indexOf('Trident', 0) !== -1;
     storage.ready().then(() => {
       storage.get('autoRefresh').then(autoRefreshTiming => {
         if (autoRefreshTiming) {

--- a/src/pages/settings/settings.html
+++ b/src/pages/settings/settings.html
@@ -15,10 +15,13 @@
     <button ion-item (click)="goToContactPage()">
       Contact PVTA
     </button>
-    <ion-item class="item" (click)="goToStorageSettingsPage()">
+    <button ion-item (click)="goToStorageSettingsPage()">
       Storage
+    </button>
+    <ion-item *ngIf="isInternetExplorer">
+      <p style="font-style: italic;">Autorefresh timing customization is not supported in Internet Explorer.</p>
     </ion-item>
-    <ion-item>
+    <ion-item *ngIf="!isInternetExplorer">
       <ion-label>Autorefresh Timing</ion-label>
       <ion-select [(ngModel)]="autoRefresh">
         <ion-option value="0">Autorefresh Off</ion-option>

--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -13,6 +13,7 @@ import * as _ from 'lodash';
 import * as moment from 'moment';
 import { ConnectivityService } from '../../providers/connectivity.service';
 import { AutoRefreshService } from '../../providers/auto-refresh.service';
+import { InfoService } from '../../providers/info.service';
 
 
 @Component({
@@ -31,13 +32,15 @@ export class StopComponent {
   // autoRefreshTime: number;
   order: String;
   stop: Stop;
+  isInternetExplorer: boolean = false;
   constructor(public navCtrl: NavController, private navParams: NavParams,
-    private stopDepartureSvc: StopDepartureService,
+    private stopDepartureSvc: StopDepartureService, private infoSvc: InfoService,
     private routeSvc: RouteService, private changer: ChangeDetectorRef,
     private loadingCtrl: LoadingController, private favoriteStopSvc: FavoriteStopService,
     private stopSvc: StopService, private connection: ConnectivityService,
     private storage: Storage, private refreshSvc: AutoRefreshService) {
       this.stopId = navParams.get('stopId');
+      this.isInternetExplorer = infoSvc.isInternetExplorer();
       this.order = '0';
   }
 

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -10,7 +10,7 @@
       </button>
     </ion-buttons>
   </ion-navbar>
-  <ion-toolbar color="primary">
+  <ion-toolbar color="primary" *ngIf="!isInternetExplorer">
     <ion-item color="primary">
       <ion-label style="color:white;">Order Departures By</ion-label>
       <ion-select [(ngModel)]="order">
@@ -24,95 +24,88 @@
 <ion-content text-wrap>
   <ion-list no-lines>
     <div *ngIf="order == '0'">
-    <div *ngFor="let direction of departuresByDirection">
-       <div ion-item (click)="toggleRouteDropdown(direction)"
-        [style.background-color]="'#'+routeList[direction.RouteId]?.Color"
-        [style.color]="'white'">
-        <!-- [ngClass]="{active: isRouteDropdownShown({{direction}})}" -->
-         <ion-grid>
-           <ion-row>
-           <ion-col class="route-shortname">
-             {{routeList[direction.RouteId]?.RouteAbbreviation}}
-           </ion-col>
-           <ion-col width-50>
-             {{direction.Departures[0].Trip.InternetServiceDesc}}
-           </ion-col>
-           <ion-col width-33 right>
-             <span>
-               {{direction.Departures[0].Times.eExact}}
-             </span>
-             <p style="color: white">
-               ({{direction.Departures[0].Times.eRelativeNoPrefix}})
-             </p>
-           </ion-col>
-         </ion-row>
-         </ion-grid>
-       </div>
-       <!-- When a route has been expanded, show its departures -->
-       <div ion-item *ngFor="let departure of direction.Departures"
-                      [hidden]="!isRouteDropdownShown(direction)"
-                      (click)="goToRoutePage(direction.RouteId)">
-                      <!-- ^^ this was part of that tag >> class="item-accordion" -->
-         <div class="bold center">
-           {{departure.Trip.InternetServiceDesc}}
-         </div>
-           <ion-grid>
-             <ion-row>
-               <ion-col>
-                 <div class="center">
-                   <b>Scheduled</b>
-                 </div>
-               </ion-col>
-               <ion-col>
-                 <div class="center">
-                   <b>Estimated</b>
-                 </div>
-               </ion-col>
-             </ion-row>
-             <ion-row>
-               <ion-col>
-                 <div class="center departure-padding">
-                   {{departure.Times.sExact}}
-                 </div>
-                 <div class="center">
-                   ({{departure.Times.sRelative}})
-                 </div>
-               </ion-col>
-               <ion-col>
-                 <div class="center departure-padding">
-                   {{departure.Times.eExact}}
-                 </div>
-                 <div class="center">
-                   ({{departure.Times.eRelative}})
-                 </div>
-               </ion-col>
-             </ion-row>
-           </ion-grid>
-       </div>
-     </div>
-   </div>
-     <div *ngIf="order == '1'">
-       <div ion-item *ngFor="let direction of departuresByTime"
-        (click)="goToRoutePage(direction.RouteId)"
-        [style.background-color]="'#'+routeList[direction.RouteId]?.Color"
-        [style.color]="'white'">
+      <div *ngFor="let direction of departuresByDirection">
+        <div ion-item (click)="toggleRouteDropdown(direction)" [style.background-color]="'#'+routeList[direction.RouteId]?.Color" [style.color]="'white'">
+          <!-- [ngClass]="{active: isRouteDropdownShown({{direction}})}" -->
+          <ion-grid>
+            <ion-row>
+              <ion-col class="route-shortname">
+                {{routeList[direction.RouteId]?.RouteAbbreviation}}
+              </ion-col>
+              <ion-col width-50>
+                {{direction.Departures[0].Trip.InternetServiceDesc}}
+              </ion-col>
+              <ion-col width-33 right>
+                <span>
+                  {{direction.Departures[0].Times.eExact}}
+                </span>
+                <p style="color: white">
+                  ({{direction.Departures[0].Times.eRelativeNoPrefix}})
+                </p>
+              </ion-col>
+            </ion-row>
+          </ion-grid>
+        </div>
+        <!-- When a route has been expanded, show its departures -->
+        <div ion-item *ngFor="let departure of direction.Departures" [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
+          <!-- ^^ this was part of that tag >> class="item-accordion" -->
+          <div class="bold center">
+            {{departure.Trip.InternetServiceDesc}}
+          </div>
+          <ion-grid>
+            <ion-row>
+              <ion-col>
+                <div class="center">
+                  <b>Scheduled</b>
+                </div>
+              </ion-col>
+              <ion-col>
+                <div class="center">
+                  <b>Estimated</b>
+                </div>
+              </ion-col>
+            </ion-row>
+            <ion-row>
+              <ion-col>
+                <div class="center departure-padding">
+                  {{departure.Times.sExact}}
+                </div>
+                <div class="center">
+                  ({{departure.Times.sRelative}})
+                </div>
+              </ion-col>
+              <ion-col>
+                <div class="center departure-padding">
+                  {{departure.Times.eExact}}
+                </div>
+                <div class="center">
+                  ({{departure.Times.eRelative}})
+                </div>
+              </ion-col>
+            </ion-row>
+          </ion-grid>
+        </div>
+      </div>
+    </div>
+    <div *ngIf="order == '1'">
+      <div ion-item *ngFor="let direction of departuresByTime" (click)="goToRoutePage(direction.RouteId)" [style.background-color]="'#'+routeList[direction.RouteId]?.Color" [style.color]="'white'">
         <ion-grid>
           <ion-row>
-          <ion-col class="route-shortname">
-            {{routeList[direction.RouteId]?.RouteAbbreviation}}
-          </ion-col>
-          <ion-col width-50>
-            {{direction.Departures?.Trip.InternetServiceDesc}}
-          </ion-col>
-          <ion-col width-33 right>
-            <span>
-              {{direction.Departures?.Times.eExact}}
-            </span>
-            <p style="color: white">
-              ({{direction.Departures?.Times.eRelativeNoPrefix}})
-            </p>
-          </ion-col>
-        </ion-row>
+            <ion-col class="route-shortname">
+              {{routeList[direction.RouteId]?.RouteAbbreviation}}
+            </ion-col>
+            <ion-col width-50>
+              {{direction.Departures?.Trip.InternetServiceDesc}}
+            </ion-col>
+            <ion-col width-33 right>
+              <span>
+                {{direction.Departures?.Times.eExact}}
+              </span>
+              <p style="color: white">
+                ({{direction.Departures?.Times.eRelativeNoPrefix}})
+              </p>
+            </ion-col>
+          </ion-row>
         </ion-grid>
       </div>
     </div>

--- a/src/providers/info.service.ts
+++ b/src/providers/info.service.ts
@@ -1,9 +1,12 @@
 import { Injectable } from '@angular/core';
+import { ToastController} from 'ionic-angular';
 
 @Injectable()
 export class InfoService {
-
-  constructor() {
+  private isIE: boolean;
+  private ieToast;
+  constructor(private toast: ToastController) {
+    this.isIE = false;
   }
 
   getVersionNumber(): string {
@@ -12,6 +15,27 @@ export class InfoService {
 
   getVersionName(): string {
     return 'UI Overhaul Beta 2';
+  }
+
+  setInternetExplorer(isIE: boolean): void {
+    this.isIE = isIE;
+    if (this.isIE === true) {
+      if (this.ieToast) {
+        this.ieToast.dismiss();
+        this.ieToast = null;
+      }
+      this.ieToast = this.toast.create({
+        message: `PVTrAck does not fully support Internet Explorer.
+        For the best experience, please switch to
+        Google Chrome or Microsoft Edge.`,
+        duration: 10000
+      });
+      this.ieToast.present();
+    }
+  }
+
+  isInternetExplorer(): boolean {
+    return this.isIE;
   }
 
 }


### PR DESCRIPTION
Ionic 2 technically doesn't support IE, so this makes it a little clearer in the following ways.

1. Using the ES7 `Array.prototype.includes()` was causing crashes, so I switched to lodash's `_.includes()`.
2. When the app loads (regardless of which page), you get the following toast for 10 seconds
![image](https://cloud.githubusercontent.com/assets/7144148/24569066/78b744fa-1632-11e7-892b-ed44b3f9c6c1.png)

3. `<ion-select>` doesn't work at all in IE.  We run into this issue on `Stop`, `Routes and Stops`, `Plan Trip`, and `Settings`.

- On `R&S` and `Stop`, we simply remove the bar with the `<select>`

![image](https://cloud.githubusercontent.com/assets/7144148/24568994/2c5f2e2e-1632-11e7-9b18-63c5f20f1620.png)

![image](https://cloud.githubusercontent.com/assets/7144148/24569010/40eee30c-1632-11e7-9262-dba4be69c03e.png)

- On `Plan Trip` and `Settings`, we tell the user that this feature isn't supported.


![image](https://cloud.githubusercontent.com/assets/7144148/24569048/6029f266-1632-11e7-9270-408d2df64c6f.png)

![image](https://cloud.githubusercontent.com/assets/7144148/24569050/63dd10e6-1632-11e7-9a42-a84427504266.png)
