### PR TITLE
Paginate Stop Lists [v2]

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ionic-native": "2.4.1",
     "ionicons": "3.0.0",
     "moment": "^2.17.1",
+    "ng2-pagination": "^2.0.1",
     "rxjs": "5.0.1",
     "sw-toolbox": "3.4.0",
     "zone.js": "0.7.2"

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,6 +6,7 @@ import { IonicStorageModule } from '@ionic/storage';
 import { MyApp } from './app.component';
 import 'intl';
 import 'intl/locale-data/jsonp/en';
+import { Ng2PaginationModule } from 'ng2-pagination';
 
 // Pages
 import { AboutComponent } from '../pages/about/about.component';
@@ -76,7 +77,8 @@ import { AutoRefreshService } from '../providers/auto-refresh.service';
       ]
     }),
     IonicStorageModule.forRoot(),
-    HttpModule
+    HttpModule,
+    Ng2PaginationModule
   ],
   bootstrap: [IonicApp],
   entryComponents: [

--- a/src/modals/stop-modal/stop.modal.html
+++ b/src/modals/stop-modal/stop.modal.html
@@ -20,20 +20,17 @@
     (ionInput)="onSearchQueryChanged($event)">
     <!-- (ionCancel)="onCancel($event)"> -->
   </ion-searchbar>
-  <ion-item *ngIf="stopsDisp.length === 0">
-    Search above to see stops.
-  </ion-item>
   <ion-list id="stops" role="list" aria-label="stops" *ngIf="requester === 1" text-wrap>
-    <ion-item role="heading" *ngFor="let stop of stopsDisp | slice:0:40">
-      <button ion-item
-        (click)="goToStopPage(stop.StopId)">
+    <button ion-item role="heading" *ngFor="let stop of stopsDisp | paginate: { itemsPerPage: 40, currentPage: p }" (click)="goToStopPage(stop.StopId)">
+
+
         <ion-icon name="pin" style="margin-right: 10px"></ion-icon>
         <span>{{stop.Description}} ({{stop.StopId}})</span>
-      </button>
-    </ion-item>
+
+    </button>
   </ion-list>
   <ion-list role="list" *ngIf="requester === 0" text-wrap>
-    <ion-item *ngFor="let stop of stopsDisp | slice:0:40">
+    <ion-item *ngFor="let stop of stopsDisp | paginate: { itemsPerPage: 40, currentPage: p }">
       <ion-label>{{stop.Description}} ({{stop.StopId}})
       </ion-label>
       <ion-checkbox color="primary" checked="{{stop.Liked}}"
@@ -41,4 +38,5 @@
       </ion-checkbox>
     </ion-item>
   </ion-list>
+  <pagination-controls center class="pages" (pageChange)="p = $event"></pagination-controls>
 </ion-content>

--- a/src/modals/stop-modal/stop.modal.ts
+++ b/src/modals/stop-modal/stop.modal.ts
@@ -32,11 +32,13 @@ export class StopModal {
   ) {
     this.requester = <StopModalRequester> this.params.get('requester');
     this.title = this.params.get('title');
-    this.stops = this.params.get('stops');
     if (this.requester === StopModalRequester.MyBuses) {
       this.ariaTitle = 'Add favorite stops popup. Check the stops you want to favorite, and click done.';
     } else {
       this.ariaTitle = this.title;
+      this.stops = this.params.get('stops');
+      this.stopsDisp = this.stops;
+
     }
     }
 
@@ -87,6 +89,7 @@ export class StopModal {
       this.storage.get('favoriteStops').then((favoriteStops: Stop[]) => {
         this.favoriteStops = favoriteStops;
         this.stops = this.prepareStops();
+        this.stopsDisp = this.stops;
       });
     });
   }

--- a/src/pages/routes-and-stops/routes-and-stops.html
+++ b/src/pages/routes-and-stops/routes-and-stops.html
@@ -45,7 +45,7 @@
     </ion-list>
 
     <ion-list text-wrap *ngSwitchCase="'stops'">
-      <button ion-item *ngFor="let stop of stopsDisp | slice:0:40"
+      <button ion-item *ngFor="let stop of stopsDisp | paginate: { itemsPerPage: 40, currentPage: p }"
         (click)="goToStopPage(stop.StopId)">
         <ion-icon name="pin" style="margin-right: 10px"></ion-icon>
         <span>{{stop.Description}} ({{stop.StopId}})</span>
@@ -53,6 +53,7 @@
           <ion-icon name="{{stop.Liked ? 'ios-heart' : 'ios-heart-outline'}}"></ion-icon>
         </button>
       </button>
+      <pagination-controls center class="pages" (pageChange)="p = $event"></pagination-controls>
     </ion-list>
   </div>
 </ion-content>

--- a/src/providers/stop.service.ts
+++ b/src/providers/stop.service.ts
@@ -72,7 +72,7 @@ export class StopService {
   }
   filterStopsByQuery(stops: Stop[], query: string): Stop[] {
     if (!query || query === '') {
-      return [];
+      return stops;
     }
     query = query.toLowerCase().trim();
     return _.filter(stops, stop => {


### PR DESCRIPTION
Closes #338.  Uses the MIT-licensed [ng2-paginate](https://github.com/michaelbromley/ng2-pagination) library.  Could be a little prettier but it's fast, simple (implementation-wise), and intuitive (UX).

It's applied to
1. The Stop Modal, used on MyBuses and Route
2. The stops list on Routes and Stops

![image](https://cloud.githubusercontent.com/assets/7144148/24574789/043d216a-1666-11e7-858e-d8e1104fcc69.png)

@sherson you were pushing for this, thoughts?