### PR TITLE
Add the 'no upcoming departures' to stop page

### DIFF
--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -113,6 +113,11 @@
       </div>
     </div>
   </ion-list>
+
+  <ion-toolbar *ngIf="!departuresByDirection.length && stop">
+    {{stop.Description}} has no departures for at least the next 3 hours.
+  </ion-toolbar>
+
   <ion-item>
     <i>Disclaimer:</i>
     <p>


### PR DESCRIPTION
Closes #354.

![image](https://cloud.githubusercontent.com/assets/7144148/24815003/ab9b4dca-1ba1-11e7-8339-c69570951b26.png)
It's true.