### PR TITLE
Fix Online and Offline Listeners

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -58,21 +58,21 @@ export class MyApp {
     });
   }
   onAppPause = () => {
-    console.log('pause');
+    console.log('App: pause');
     window.removeEventListener('offline', this.onDeviceOffline);
     window.removeEventListener('online', this.onDeviceOnline);
   }
   onAppResume = () => {
-    console.log('resume');
+    console.log('App: resume');
     window.addEventListener('offline', this.onDeviceOffline, false);
     window.addEventListener('online', this.onDeviceOnline, false);
   }
   onDeviceOffline = () => {
-    console.log('offline');
+    console.log('App: offline');
     this.connectivityService.setConnectionStatus(false);
   }
   onDeviceOnline = () => {
-    console.log('online');
+    console.log('App: online');
     this.connectivityService.setConnectionStatus(true);
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -49,21 +49,23 @@ export class MyApp {
       this.infoSvc.setInternetExplorer(isIE);
       this.showNativeStoreAd = this.platform.is('mobileweb') || this.platform.is('core');
       Splashscreen.hide();
+      // Must use document for pause/resume, and window for on/offline.
+      // Great question.
       document.addEventListener('pause', this.onAppPause);
       document.addEventListener('resume', this.onAppResume);
-      document.addEventListener('offline', this.onDeviceOffline, false);
-      document.addEventListener('online', this.onDeviceOnline, false);
+      window.addEventListener('offline', this.onDeviceOffline, false);
+      window.addEventListener('online', this.onDeviceOnline, false);
     });
   }
   onAppPause = () => {
     console.log('pause');
-    document.removeEventListener('offline', this.onDeviceOffline);
-    document.removeEventListener('online', this.onDeviceOnline);
+    window.removeEventListener('offline', this.onDeviceOffline);
+    window.removeEventListener('online', this.onDeviceOnline);
   }
   onAppResume = () => {
     console.log('resume');
-    document.addEventListener('offline', this.onDeviceOffline, false);
-    document.addEventListener('online', this.onDeviceOnline, false);
+    window.addEventListener('offline', this.onDeviceOffline, false);
+    window.addEventListener('online', this.onDeviceOnline, false);
   }
   onDeviceOffline = () => {
     console.log('offline');

--- a/src/app/main.ts
+++ b/src/app/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 import { gaInit } from './ga.ts';
 gaInit();
 
-declare const ENV;
+declare const ENV, ga;
 
 var head = document.getElementsByTagName('head')[0];
 var mapsApi = document.createElement('script');

--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -54,11 +54,11 @@ export class StopComponent {
   }
 
   handleAppPause = () => {
-    console.log('pause');
+    console.log('StopComponent: pause');
     clearInterval(this.interval);
   }
   handleAppResume = () => {
-    console.log('resume');
+    console.log('StopComponent: resume');
     this.ionViewWillEnter();
   }
 


### PR DESCRIPTION
Closes #362.  This functionality previously existed but was broken by #361.  This PR sets the listeners on the correct global object. I was using `document` everywhere, but the online/offline listeners must be set on `window`.

The goal of #361 is still achieved, this just fixes what it broke.