### PR TITLE
Pull to refresh on Stop Page

### DIFF
--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -35,6 +35,7 @@ export class StopComponent {
   title: string;
   order: String;
   stop: Stop;
+  loaderIsShown: boolean = false;
   isInternetExplorer: boolean = false;
   constructor(public navCtrl: NavController, private navParams: NavParams,
     private stopDepartureSvc: StopDepartureService, private infoSvc: InfoService,
@@ -68,9 +69,14 @@ export class StopComponent {
         duration: 3000
       });
       this.loader.present();
+      this.loaderIsShown = true;
+      this.loader.onDidDismiss(() => {
+        this.loaderIsShown = false;
+      });
   }
+
   hideLoader(): void {
-    if (this.loader) {
+    if (this.loader && this.loaderIsShown) {
       this.loader.dismiss();
     }
   }
@@ -87,7 +93,7 @@ export class StopComponent {
         this.hideLoader();
         if (refresher) refresher.complete();
     }).catch(err => {
-      console.error(err);
+      console.error(`Couldn't download departures, error: ${err}`);
       this.hideLoader();
       if (refresher) refresher.complete();
     });
@@ -115,10 +121,10 @@ export class StopComponent {
             }, autoRefresh);
         }
       }).catch(err => {
-        console.error(err);
+        console.error(`Error retrieving refresh time: ${err}`);
       });
     }).catch(err => {
-      console.error(err);
+      console.error(`Error connecting to local storage: ${err}`);
     });
     this.stopSvc.getStop(this.stopId).then(stop => {
       this.stop = stop;
@@ -126,7 +132,7 @@ export class StopComponent {
       ga('send', 'event', 'StopLoaded',
       'StopComponent.ionViewWillEnter', `Stop: ${stop.Description} (${this.stopId})`);
     }).catch(err => {
-      console.error(err);
+      console.error(`Error downloading stop details: ${err}`);
     });
   }
 
@@ -149,7 +155,7 @@ export class StopComponent {
       .then(route => {
         this.routeList[id] = (route);
       }).catch(err => {
-        console.error(err);
+        console.error(`Error downloading details for ${id}: ${err}`);
       });
   }
   // Calls getRoute() for each RouteId in
@@ -276,6 +282,8 @@ export class StopComponent {
  goToRoutePage(routeId: number): void {
    this.navCtrl.push(RouteComponent, {
      routeId: routeId
+   }).catch(() => {
+     console.error('Unable to go to route page');
    });
  }
  goToStopMapPage(): void {

--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -75,14 +75,21 @@ export class StopComponent {
     }
   }
 
-  getDepartures(): void {
+  pullToRefresh(refresher): void {
+    this.getDepartures(refresher);
+  }
+
+  getDepartures(refresher?: any): void {
     this.stopDepartureSvc.getStopDeparture(this.stopId)
       .then(directions => {
         this.sort(directions[0]);
         this.getRoutes(_.uniq(_.map(directions[0].RouteDirections, 'RouteId')));
         this.hideLoader();
+        if (refresher) refresher.complete();
     }).catch(err => {
       console.error(err);
+      this.hideLoader();
+      if (refresher) refresher.complete();
     });
   }
 

--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -35,7 +35,6 @@ export class StopComponent {
   title: string;
   order: String;
   stop: Stop;
-  loaderIsShown: boolean = false;
   isInternetExplorer: boolean = false;
   constructor(public navCtrl: NavController, private navParams: NavParams,
     private stopDepartureSvc: StopDepartureService, private infoSvc: InfoService,
@@ -66,17 +65,12 @@ export class StopComponent {
   presentLoader(): void {
       this.loader = this.loadingCtrl.create({
         content: 'Downloading departures...',
-        duration: 3000
       });
       this.loader.present();
-      this.loaderIsShown = true;
-      this.loader.onDidDismiss(() => {
-        this.loaderIsShown = false;
-      });
   }
 
   hideLoader(): void {
-    if (this.loader && this.loaderIsShown) {
+    if (this.loader) {
       this.loader.dismiss();
     }
   }

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -25,6 +25,10 @@
 </ion-header>
 
 <ion-content text-wrap>
+  <ion-refresher (ionRefresh)="pullToRefresh($event)">
+    <ion-refresher-content pullingText="Pull to refresh departures...">
+    </ion-refresher-content>
+  </ion-refresher>
   <ion-list no-lines>
     <div *ngIf="order == '0'">
       <div *ngFor="let direction of departuresByDirection">


### PR DESCRIPTION
Closes #365.  Adds pull-to-refresh ability on the Stop page.  

Also fixes an issue where users with really slow connections might experience an `Uncaught in Promise (false)` crash.  
This was a result of setting a default timeout on the page's loader.  After 3 seconds, the loader auto-hid, and when the web request eventually returned and we tried to hide the loader manually, it crashed.
I fixed it by just removing the autohide, whatevs.