### PR TITLE
Load the 1.x Database in 2.x So Users Don't "Lose" Their Favorites

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -76,7 +76,8 @@ import { AutoRefreshService } from '../providers/auto-refresh.service';
         {component: StopMapComponent, name: 'Stop Map', segment: 'stop/:stopId/map', defaultHistory: [MyBusesComponent]},
       ]
     }),
-    IonicStorageModule.forRoot(),
+    // For backwards compatibility with V1 users' storage!
+    IonicStorageModule.forRoot({name: 'localforage', storeName: 'keyvaluepairs'}),
     HttpModule,
     Ng2PaginationModule
   ],


### PR DESCRIPTION
Turns out, Ionic 2 apps, by default, create Storage databases with different names than Ionic 1 apps.

This PR sets Pvtrack 2's database to use the same name as Pvtrack 1's so that our users who update from 1 to 2 don't lose all their favorites!  We still get the same improvements that Ionic2 provides, but we no longer have to lose all our existing stuff.