### PR TITLE
Native chrome install banner

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -48,6 +48,9 @@ export class MyApp {
       let isIE: boolean = navigator.userAgent.indexOf('Trident', 0) !== -1;
       this.infoSvc.setInternetExplorer(isIE);
       this.showNativeStoreAd = this.platform.is('mobileweb') || this.platform.is('core');
+      if (this.showNativeStoreAd) {
+        window.addEventListener('beforeinstallprompt', this.onInstallPromptShown);
+      }
       Splashscreen.hide();
       // Must use document for pause/resume, and window for on/offline.
       // Great question.
@@ -74,6 +77,18 @@ export class MyApp {
   onDeviceOnline = () => {
     console.log('App: online');
     this.connectivityService.setConnectionStatus(true);
+  }
+  onInstallPromptShown = (e: any) => {
+    // beforeinstallprompt Event fired
+    // e.userChoice will return a Promise.
+    e.userChoice.then(choiceResult => {
+      console.log(choiceResult.outcome);
+      if(choiceResult.outcome == 'dismissed') {
+        console.log('User cancelled home screen install');
+      } else {
+        console.log('User added to home screen');
+      }
+    });
   }
 
   openPage(page) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -82,12 +82,8 @@ export class MyApp {
     // beforeinstallprompt Event fired
     // e.userChoice will return a Promise.
     e.userChoice.then(choiceResult => {
-      console.log(choiceResult.outcome);
-      if(choiceResult.outcome == 'dismissed') {
-        console.log('User cancelled home screen install');
-      } else {
-        console.log('User added to home screen');
-      }
+      ga('send', 'event', 'Native App Install Banner Interaction',
+      'AppComponent.initializeApp()', choiceResult.outcome);
     });
   }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -20,7 +20,7 @@ export class MyApp {
   rootPage: any = MyBusesComponent;
   offlineToast;
   pages: Array<{title: string, component: any}>;
-  showNativeStoreAd = false;
+  runningInBrowser = false;
 
   constructor(public platform: Platform, private infoSvc: InfoService,
   private connectivityService: ConnectivityService) {
@@ -47,8 +47,9 @@ export class MyApp {
       }
       let isIE: boolean = navigator.userAgent.indexOf('Trident', 0) !== -1;
       this.infoSvc.setInternetExplorer(isIE);
-      this.showNativeStoreAd = this.platform.is('mobileweb') || this.platform.is('core');
-      if (this.showNativeStoreAd) {
+      this.runningInBrowser = this.platform.is('mobileweb') || this.platform.is('core');
+      // Listen for the app install banner interactions
+      if (this.runningInBrowser) {
         window.addEventListener('beforeinstallprompt', this.onInstallPromptShown);
       }
       Splashscreen.hide();

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -12,7 +12,7 @@
           {{p.title}}
         </button>
       </ion-list>
-      <div style="position: absolute; bottom: 1%; margin-left: 5%;" *ngIf="showNativeStoreAd">
+      <div style="position: absolute; bottom: 1%; margin-left: 5%;" *ngIf="runningInBrowser">
         <div onclick="window.open('https://play.google.com/store/apps/details?id=com.umts.pvtamultiplaform', '_blank');">
           <ion-icon color="dark-green" name="md-appstore" aria-label="Play Store Link"></ion-icon>
           <a>Get PVTrAck on Android!</a>

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,10 +1,17 @@
 {
-  "name": "PVTrAck - The Official App of the Pioneer Valley Transit Authority",
+  "name": "PVTrAck",
   "short_name": "PVTrAck",
   "theme_color": "#2196F3",
   "start_url": "index.html",
   "background_color": "#1976D2",
   "display": "standalone",
+  "prefer_related_applications": true,
+  "related_applications": [
+    {
+      "platform": "play",
+      "id": "com.umts.pvtamultiplaform"
+    }
+  ],
   "icons": [
     {
       "src": "assets/icon/android-chrome-512x512.png",


### PR DESCRIPTION
Closes #283 for real this time.

Adds to the `manifest.json` the required info for Chrome on Android showing a popup to download the app from the Play Store, then sends analytics regarding how the user responded.