### PR TITLE
Walking directions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ before_install:
   - nvm install node
   - nvm use node
   - npm install -g cordova ionic
-  - ionic state clear
 
 install: npm install
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To begin developing, follow these steps:
 
 ## Setup
 
-1. Clone repository
+1. Clone repository, cd into it.
 
 2. Run `npm install`
 

--- a/ionic.config.json
+++ b/ionic.config.json
@@ -1,6 +1,5 @@
 {
   "name": "PVTrAck",
   "app_id": "",
-  "v2": true,
-  "typescript": true
+  "type": "ionic-angular"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ionic:serve": "ionic-app-scripts serve",
     "test": "karma start ./test-config/karma.conf.js",
     "test-coverage": "karma start ./test-config/karma.conf.js --coverage",
-    "test-ci": "karma start ./test-config/karma.conf.js --single-run --coverage" ,
+    "test-ci": "karma start ./test-config/karma.conf.js --single-run --coverage",
     "e2e": "webdriver-manager update --standalone false --gecko false; protractor ./test-config/protractor.conf.js"
   },
   "config": {
@@ -51,6 +51,7 @@
     "@ionic/app-scripts": "1.1.4",
     "@ionic/cli-build-ionic-angular": "0.0.3",
     "@ionic/cli-plugin-cordova": "0.0.9",
+    "@ionic/cli-plugin-ionic-angular": "1.0.0",
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.8",
     "angular2-template-loader": "^0.6.2",

--- a/src/pages/plan-trip/plan-trip.html
+++ b/src/pages/plan-trip/plan-trip.html
@@ -73,14 +73,14 @@
         <ion-item-divider color="light">Destination</ion-item-divider>
         <ion-item>{{route['end_address']}}</ion-item>
       </ion-item-group>
-      <ion-item-group>
+      <ion-item-group *ngIf="route['departure_time']">
         <ion-item-divider color="light">Departure Time:</ion-item-divider>
         <ion-item>
           {{route['departure_time']['value'] | date: "h:mm a"}},
           {{route['departure_time']['value'] | date: "EEEE dd MMM yyyy"}}
         </ion-item>
       </ion-item-group>
-      <ion-item-group>
+      <ion-item-group *ngIf="route['arrival_time']">
         <ion-item-divider color="light">Arrival Time:</ion-item-divider>
         <ion-item>
           {{route['arrival_time']['value'] | date: "h:mm a"}},


### PR DESCRIPTION
Google does not provide arrival and departure times when public transit is not involved in a trip (so, if you're only walking). The app tried to fetch arrival and departure times anyways, so on trips where there was only walking (so from here to the campus store, for example), an error would be thrown trying to fetch a null value.
Put an ngIf in there to check for existence and fetched those values only if they are present.