### PR TITLE
Move List Picker on Routes And Stops

### DIFF
--- a/src/pages/routes-and-stops/routes-and-stops.html
+++ b/src/pages/routes-and-stops/routes-and-stops.html
@@ -5,20 +5,22 @@
     </button>
     <ion-title role="heading">Routes and Stops</ion-title>
   </ion-navbar>
-  <ion-segment [(ngModel)]="cDisplay" (ionChange)="toggleOrdering()">
-    <ion-segment-button value="routes">
-      Routes
-    </ion-segment-button>
-    <ion-segment-button value="stops">
-      Stops
-    </ion-segment-button>
-  </ion-segment>
   <ion-searchbar
     [(ngModel)]="searchQuery"
     showCancelButton
     (ionInput)="onSearchQueryChanged($event.target.value)">
     <!-- (ionCancel)="onCancel($event)"> -->
   </ion-searchbar>
+  <ion-toolbar>
+    <ion-segment [(ngModel)]="cDisplay" (ionChange)="toggleOrdering()">
+      <ion-segment-button value="routes">
+        Routes
+      </ion-segment-button>
+      <ion-segment-button value="stops">
+        Stops
+      </ion-segment-button>
+    </ion-segment>
+  </ion-toolbar>
   <ion-item *ngIf="!isInternetExplorer">
     <ion-label>Order {{cDisplay == 'routes' ? 'Routes' : 'Stops'}} By:</ion-label>
     <ion-select [(ngModel)]="order" (ionChange)="toggleOrdering()">
@@ -28,7 +30,7 @@
     </ion-select>
   </ion-item>
 </ion-header>
-<ion-content padding>
+<ion-content>
   <div [ngSwitch]="cDisplay">
     <ion-list role="list" aria-label="all routes" text-wrap *ngSwitchCase="'routes'">
       <div ion-item *ngFor="let route of routesDisp"


### PR DESCRIPTION
The iOS version looks really sucky:

![image](https://cloud.githubusercontent.com/assets/7144148/25956709/6f0d2ffa-363a-11e7-987b-745951009eed.png)

I simply moved the segment to...lower down.
I also removed the padding, because you'll notice that under the "Order Routes By..." bar, there's 2 lines!

The proposed changes look like this on iOS:

![image](https://cloud.githubusercontent.com/assets/7144148/25956837/cf869f88-363a-11e7-803f-dd5e39e53671.png)

They look like this on Android:

![image](https://cloud.githubusercontent.com/assets/7144148/25956857/e237a5b4-363a-11e7-94d5-8456c092df2c.png)


See the changes live at https://m.pvta.com/beta/#/routes-and-stops.