### PR TITLE
Rework Stop Dropdown

### DIFF
--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -173,15 +173,35 @@ export class StopComponent {
    * either a scheduled time ('s') or an estimated time ('e').
    */
   calculateTimes (departure): Object {
+    let sdt = moment(departure.SDT);
+    let edt = moment(departure.EDT);
+    // Avail bug: tripStart date is wrong, but time is correct
+    let badTrip = moment(departure.Trip.TripStartTime);
+    let tripStartAdjusted = moment()
+      .hour(badTrip.hour())
+      .minute(badTrip.minute())
+      .second(0)
+      .millisecond(0);
+    // Trip has started if start time is in the past
+    let msUntilTripStarts = tripStartAdjusted.diff(moment());
+    let tripHasStarted = msUntilTripStarts < 0;
+    // ex: '6 minutes'
+    let sRelativeNoPrefix =  moment(sdt).fromNow(true);
+    let eRelativeNoPrefix = moment(edt).fromNow(true);
+    let sRelative = moment(sdt).fromNow();
+    let eRelative = moment(edt).fromNow();
     return {
+      // ex: '2 minutes'
+      estLateness: edt.diff(sdt, 'minutes'),
+      tripStarted: tripHasStarted,
+      msUntilTripStarts: msUntilTripStarts,
       // ex: '8:12 PM'
-      sExact: moment(departure.SDT).format('LT'),
-      eExact: moment(departure.EDT).format('LT'),
-      // ex: 'in 6 minutes'
-      sRelative: moment(departure.SDT).fromNow(),
-      eRelative: moment(departure.EDT).fromNow(),
-      // ex: '6 minutes'
-      eRelativeNoPrefix: moment(departure.EDT).fromNow(true)
+      sExact: moment(sdt).format('LT'),
+      eExact: moment(edt).format('LT'),
+      sRelative: sRelative,
+      eRelative: eRelative,
+      sRelativeNoPrefix: sRelativeNoPrefix,
+      eRelativeNoPrefix: eRelativeNoPrefix
     };
   }
   /**

--- a/src/pages/stop/stop.component.ts
+++ b/src/pages/stop/stop.component.ts
@@ -175,16 +175,6 @@ export class StopComponent {
   calculateTimes (departure): Object {
     let sdt = moment(departure.SDT);
     let edt = moment(departure.EDT);
-    // Avail bug: tripStart date is wrong, but time is correct
-    let badTrip = moment(departure.Trip.TripStartTime);
-    let tripStartAdjusted = moment()
-      .hour(badTrip.hour())
-      .minute(badTrip.minute())
-      .second(0)
-      .millisecond(0);
-    // Trip has started if start time is in the past
-    let msUntilTripStarts = tripStartAdjusted.diff(moment());
-    let tripHasStarted = msUntilTripStarts < 0;
     // ex: '6 minutes'
     let sRelativeNoPrefix =  moment(sdt).fromNow(true);
     let eRelativeNoPrefix = moment(edt).fromNow(true);
@@ -193,8 +183,6 @@ export class StopComponent {
     return {
       // ex: '2 minutes'
       estLateness: edt.diff(sdt, 'minutes'),
-      tripStarted: tripHasStarted,
-      msUntilTripStarts: msUntilTripStarts,
       // ex: '8:12 PM'
       sExact: moment(sdt).format('LT'),
       eExact: moment(edt).format('LT'),

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -35,7 +35,6 @@
     <div *ngIf="order == '0'">
       <div *ngFor="let direction of departuresByDirection">
         <div ion-item (click)="toggleRouteDropdown(direction)" [style.background-color]="'#'+routeList[direction.RouteId]?.Color" [style.color]="'white'">
-          <!-- [ngClass]="{active: isRouteDropdownShown({{direction}})}" -->
           <ion-grid no-padding>
             <ion-row>
               <ion-col col-3 class="route-shortname">
@@ -60,8 +59,6 @@
         </div>
         <!-- When a route has been expanded, show its departures -->
         <div [style.background-color]="'#'+routeList[direction.RouteId]?.Color" ion-item [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
-          <!-- ^^ this was part of that tag >> class="item-accordion" -->
-          
           <ion-grid style="margin-left: 10%; font-size: 90%; padding-right: 10%" [style.color]="'white'">
             <ion-row>
               <ion-col></ion-col>

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -31,26 +31,31 @@
     <ion-refresher-content pullingText="Pull to refresh departures...">
     </ion-refresher-content>
   </ion-refresher>
-  <ion-list aria-label="upcoming departures at this stop" role="list" no-lines>
+  <ion-list aria-label="upcoming departures at this stop" role="list">
     <div *ngIf="order == '0'">
       <div *ngFor="let direction of departuresByDirection">
         <div ion-item (click)="toggleRouteDropdown(direction)" [style.background-color]="'#'+routeList[direction.RouteId]?.Color" [style.color]="'white'">
           <!-- [ngClass]="{active: isRouteDropdownShown({{direction}})}" -->
           <ion-grid>
             <ion-row>
-              <ion-col class="route-shortname">
+              <ion-col col-auto class="route-shortname">
                 {{routeList[direction.RouteId]?.RouteAbbreviation}}
               </ion-col>
-              <ion-col width-50>
+              <ion-col col-6-auto style="text-align: center;">
                 {{direction.Departures[0].Trip.InternetServiceDesc}}
               </ion-col>
-              <ion-col width-33 right>
-                <span>
+              <ion-col col-auto offset-12 style="text-align: right;">
+                <p style="color: white;">
                   {{direction.Departures[0].Times.eExact}}
-                </span>
+                </p>
                 <p style="color: white">
                   ({{direction.Departures[0].Times.eRelativeNoPrefix}})
                 </p>
+              </ion-col>
+            </ion-row>
+            <ion-row>
+              <ion-col offset-11>
+                <ion-icon [name]="isRouteDropdownShown(direction) ? 'ios-arrow-up' : 'ios-arrow-down'"></ion-icon>
               </ion-col>
             </ion-row>
           </ion-grid>

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -63,17 +63,17 @@
         <!-- When a route has been expanded, show its departures -->
         <div ion-item [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
           <!-- ^^ this was part of that tag >> class="item-accordion" -->
-          <ion-grid>
+          <ion-grid style="font-size: 90%">
             <ion-row>
-              <ion-col></ion-col>
+              <ion-col col-5></ion-col>
               <ion-col>
                 <div class="center">
-                  <b>Scheduled</b>
+                  <ion-icon name="calendar" ios="ios-calendar-outline"></ion-icon>
                 </div>
               </ion-col>
               <ion-col>
                 <div class="center">
-                  <b>Estimated</b>
+                  <ion-icon name="timer" ios="ios-timer-outline"></ion-icon>
                 </div>
               </ion-col>
             </ion-row>
@@ -83,14 +83,23 @@
               </ion-col>
               <ion-col>
                 <div class="center departure-padding">
-                  {{departure.Times.sExact}}
+                  {{departure.Times.sExact}}<br>
                   ({{departure.Times.sRelative}})
                 </div>
               </ion-col>
-              <ion-col>
-                <div class="center departure-padding">
-                  {{departure.Times.eExact}}
+              <ion-col class="center departure-padding">
+                <div *ngIf="departure.Times.msUntilTripStarts < 600000">
+                  {{departure.Times.eExact}}<br>
                   ({{departure.Times.eRelativeNoPrefix}})
+                  <br>
+                  <span [style.color]="departure.Times.estLateness > 5 ? 'red' : 'green'">
+                    {{departure.Times.estLateness > 4 ?
+                    departure.Times.estLateness + ' minutes late' :
+                    'On time'}}
+                  </span>
+                </div>
+                <div *ngIf="departure.Times.msUntilTripStarts > 600000">
+                  ---- <br>
                 </div>
               </ion-col>
             </ion-row>

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -61,24 +61,24 @@
           </ion-grid>
         </div>
         <!-- When a route has been expanded, show its departures -->
-        <div ion-item [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
+        <div [style.background-color]="'#'+routeList[direction.RouteId]?.Color" ion-item [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
           <!-- ^^ this was part of that tag >> class="item-accordion" -->
-          <ion-grid style="font-size: 90%">
+          <ion-grid style="margin-left: 10%; font-size: 90%; padding-right: 10%" [style.color]="'white'">
             <ion-row>
-              <ion-col col-5></ion-col>
+              <ion-col></ion-col>
               <ion-col>
                 <div class="center">
-                  <ion-icon name="calendar" ios="ios-calendar-outline"></ion-icon>
+                  <b>Scheduled</b>
                 </div>
               </ion-col>
               <ion-col>
                 <div class="center">
-                  <ion-icon name="timer" ios="ios-timer-outline"></ion-icon>
+                  <b>Estimated</b>
                 </div>
               </ion-col>
             </ion-row>
             <ion-row *ngFor="let departure of direction.Departures">
-              <ion-col col-5 offset-0>
+              <ion-col>
                 {{departure.Trip.InternetServiceDesc}}
               </ion-col>
               <ion-col>
@@ -90,13 +90,7 @@
               <ion-col class="center departure-padding">
                 <div *ngIf="departure.Times.msUntilTripStarts < 600000">
                   {{departure.Times.eExact}}<br>
-                  ({{departure.Times.eRelativeNoPrefix}})
-                  <br>
-                  <span [style.color]="departure.Times.estLateness > 5 ? 'red' : 'green'">
-                    {{departure.Times.estLateness > 4 ?
-                    departure.Times.estLateness + ' minutes late' :
-                    'On time'}}
-                  </span>
+                  ({{departure.Times.eRelative}})
                 </div>
                 <div *ngIf="departure.Times.msUntilTripStarts > 600000">
                   ---- <br>

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -36,15 +36,15 @@
       <div *ngFor="let direction of departuresByDirection">
         <div ion-item (click)="toggleRouteDropdown(direction)" [style.background-color]="'#'+routeList[direction.RouteId]?.Color" [style.color]="'white'">
           <!-- [ngClass]="{active: isRouteDropdownShown({{direction}})}" -->
-          <ion-grid>
+          <ion-grid no-padding>
             <ion-row>
               <ion-col col-3 class="route-shortname">
                 {{routeList[direction.RouteId]?.RouteAbbreviation}}
               </ion-col>
-              <ion-col col-5 style="text-align: center;">
+              <ion-col col-4 style="text-align: left;">
                 {{direction.Departures[0].Trip.InternetServiceDesc}}
               </ion-col>
-              <ion-col col-4 style="text-align: right;">
+              <ion-col col-4 style="text-align: center;">
                 <p style="color: white;">
                   {{direction.Departures[0].Times.eExact}}
                 </p>
@@ -52,9 +52,7 @@
                   ({{direction.Departures[0].Times.eRelativeNoPrefix}})
                 </p>
               </ion-col>
-            </ion-row>
-            <ion-row>
-              <ion-col offset-11>
+              <ion-col >
                 <ion-icon [name]="isRouteDropdownShown(direction) ? 'ios-arrow-up' : 'ios-arrow-down'"></ion-icon>
               </ion-col>
             </ion-row>
@@ -63,6 +61,7 @@
         <!-- When a route has been expanded, show its departures -->
         <div [style.background-color]="'#'+routeList[direction.RouteId]?.Color" ion-item [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
           <!-- ^^ this was part of that tag >> class="item-accordion" -->
+          
           <ion-grid style="margin-left: 10%; font-size: 90%; padding-right: 10%" [style.color]="'white'">
             <ion-row>
               <ion-col></ion-col>
@@ -88,12 +87,9 @@
                 </div>
               </ion-col>
               <ion-col class="center departure-padding">
-                <div *ngIf="departure.Times.msUntilTripStarts < 600000">
+                <div>
                   {{departure.Times.eExact}}<br>
                   ({{departure.Times.eRelative}})
-                </div>
-                <div *ngIf="departure.Times.msUntilTripStarts > 600000">
-                  ---- <br>
                 </div>
               </ion-col>
             </ion-row>

--- a/src/pages/stop/stop.html
+++ b/src/pages/stop/stop.html
@@ -38,13 +38,13 @@
           <!-- [ngClass]="{active: isRouteDropdownShown({{direction}})}" -->
           <ion-grid>
             <ion-row>
-              <ion-col col-auto class="route-shortname">
+              <ion-col col-3 class="route-shortname">
                 {{routeList[direction.RouteId]?.RouteAbbreviation}}
               </ion-col>
-              <ion-col col-6-auto style="text-align: center;">
+              <ion-col col-5 style="text-align: center;">
                 {{direction.Departures[0].Trip.InternetServiceDesc}}
               </ion-col>
-              <ion-col col-auto offset-12 style="text-align: right;">
+              <ion-col col-4 style="text-align: right;">
                 <p style="color: white;">
                   {{direction.Departures[0].Times.eExact}}
                 </p>
@@ -61,13 +61,11 @@
           </ion-grid>
         </div>
         <!-- When a route has been expanded, show its departures -->
-        <div ion-item *ngFor="let departure of direction.Departures" [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
+        <div ion-item [hidden]="!isRouteDropdownShown(direction)" (click)="goToRoutePage(direction.RouteId)">
           <!-- ^^ this was part of that tag >> class="item-accordion" -->
-          <div class="bold center">
-            {{departure.Trip.InternetServiceDesc}}
-          </div>
           <ion-grid>
             <ion-row>
+              <ion-col></ion-col>
               <ion-col>
                 <div class="center">
                   <b>Scheduled</b>
@@ -79,21 +77,20 @@
                 </div>
               </ion-col>
             </ion-row>
-            <ion-row>
+            <ion-row *ngFor="let departure of direction.Departures">
+              <ion-col col-5 offset-0>
+                {{departure.Trip.InternetServiceDesc}}
+              </ion-col>
               <ion-col>
                 <div class="center departure-padding">
                   {{departure.Times.sExact}}
-                </div>
-                <div class="center">
                   ({{departure.Times.sRelative}})
                 </div>
               </ion-col>
               <ion-col>
                 <div class="center departure-padding">
                   {{departure.Times.eExact}}
-                </div>
-                <div class="center">
-                  ({{departure.Times.eRelative}})
+                  ({{departure.Times.eRelativeNoPrefix}})
                 </div>
               </ion-col>
             </ion-row>
@@ -105,16 +102,16 @@
       <div ion-item *ngFor="let direction of departuresByTime" (click)="goToRoutePage(direction.RouteId)" [style.background-color]="'#'+routeList[direction.RouteId]?.Color" [style.color]="'white'">
         <ion-grid>
           <ion-row>
-            <ion-col class="route-shortname">
+            <ion-col col-auto class="route-shortname">
               {{routeList[direction.RouteId]?.RouteAbbreviation}}
             </ion-col>
-            <ion-col width-50>
+            <ion-col col-6-auto>
               {{direction.Departures?.Trip.InternetServiceDesc}}
             </ion-col>
-            <ion-col width-33 right>
-              <span>
+            <ion-col col-auto right>
+              <p style="color: white;">
                 {{direction.Departures?.Times.eExact}}
-              </span>
+              </p>
               <p style="color: white">
                 ({{direction.Departures?.Times.eRelativeNoPrefix}})
               </p>


### PR DESCRIPTION
Inspired by a fellow driver who was baffled when I showed her that you could tap on a departure and you'd see more of them, I decided to make some changes.

For reference, the Stop page looks like this currently:

![image](https://cloud.githubusercontent.com/assets/7144148/25977081/eff03904-3686-11e7-9867-a98d17c11045.png)

When you expand a route (which is not even an obvious option), it looks like this:
![image](https://cloud.githubusercontent.com/assets/7144148/25977095/0a365c1c-3687-11e7-99e1-1db2ab418db0.png)


I redid the format of the rows (both on the main Route bars, and their departure dropdowns).  The main bar now has the almighty "arrow thingy," and the dropdown is much more compact.

Here's the new version:

![image](https://cloud.githubusercontent.com/assets/7144148/25977133/3c92754c-3687-11e7-8661-8c5407742295.png)


And expanded:

![image](https://cloud.githubusercontent.com/assets/7144148/25977135/46b7c608-3687-11e7-8092-35fddd1378b6.png)
