### PR TITLE
Update CLI Plugins

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "zone.js": "0.7.2"
   },
   "devDependencies": {
-    "@ionic/app-scripts": "1.1.4",
+    "@ionic/app-scripts": "^1.3.7",
     "@ionic/cli-build-ionic-angular": "0.0.3",
     "@ionic/cli-plugin-cordova": "0.0.9",
-    "@ionic/cli-plugin-ionic-angular": "1.0.0",
+    "@ionic/cli-plugin-ionic-angular": "^1.3.1",
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.8",
     "angular2-template-loader": "^0.6.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "devDependencies": {
     "@ionic/app-scripts": "^1.3.7",
     "@ionic/cli-build-ionic-angular": "0.0.3",
-    "@ionic/cli-plugin-cordova": "0.0.9",
+    "@ionic/cli-plugin-cordova": "1.4.0",
     "@ionic/cli-plugin-ionic-angular": "^1.3.1",
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.8",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
   },
   "devDependencies": {
     "@ionic/app-scripts": "^1.3.7",
-    "@ionic/cli-build-ionic-angular": "0.0.3",
-    "@ionic/cli-plugin-cordova": "1.4.0",
+    "@ionic/cli-build-ionic-angular": "^0.0.3",
+    "@ionic/cli-plugin-cordova": "^1.4.0",
     "@ionic/cli-plugin-ionic-angular": "^1.3.1",
     "@types/jasmine": "^2.5.41",
     "@types/node": "^7.0.8",


### PR DESCRIPTION
Closes #390.  Ionic's CLI has foiled us again, this time by breaking when we run `ionic serve` without updating the CLI's "plugins."  This PR updates the plugins to work Ionic CLI v3.4.

I've also added a preceding `^` to all CLI plugins in `package.json`; this way `npm install` will pull minor version updates (i.e. `^3.2.1` will install `3.4.2` and the like, if a package has been so updated). This will hopefully safeguard us against a similar problem in the future.