### PR TITLE
Add cooperative gesture handling for maps on plan trip

### DIFF
--- a/src/pages/plan-trip/plan-trip.component.ts
+++ b/src/pages/plan-trip/plan-trip.component.ts
@@ -211,7 +211,8 @@ private geolocation: Geolocation) {
     var mapOptions = {
       zoom: 15,
       mapTypeControl: false,
-      mapTypeId: google.maps.MapTypeId.ROADMAP
+      mapTypeId: google.maps.MapTypeId.ROADMAP,
+      gestureHandling: 'cooperative'
     };
     this.map = new google.maps.Map(this.mapElement.nativeElement, mapOptions);
     this.directionsDisplay = new google.maps.DirectionsRenderer;


### PR DESCRIPTION
Closes #397.  Adds "cooperative gesture handling" from the [Maps API](https://developers.google.com/maps/documentation/javascript/interaction#gesture-handling).  Users will be familiar with this as "that annoying thing that makes me use two fingers to move the map," but I'm convinced this is better than what we had before.

When scrolling down the Schedule page after planning a trip, you'll see this (**applies to touch-based devices only**):
![image](https://user-images.githubusercontent.com/7144148/27561634-e5e00f5a-5a96-11e7-917d-ff0fcf8bec44.png)

Confirmed working on my Nexus with mobile-Chrome 58 and has no effect on my Mac on Chrome 59.  @dfaulken, I know you don't know anything about pvtrack testing, but would you anticipate an integration test might be able to check functionality for this?