### PR TITLE
Don't crunch route text

### DIFF
--- a/src/modals/route-modal/route.modal.html
+++ b/src/modals/route-modal/route.modal.html
@@ -18,7 +18,7 @@
       </ion-checkbox>
         <ion-label>
           <ion-row wrap attr.aria-label="Route {{route.RouteAbbreviation}} {{route.GoogleDescription}}">
-            <ion-col aria-hidden="true" width-25 [style.color]="'#' + route.Color" style="font-size: 125%; font-weight: bold; margin-left: 5%">
+            <ion-col col-2 aria-hidden="true" width-25 [style.color]="'#' + route.Color" style="font-size: 125%; font-weight: bold; margin-left: 5%">
               {{route.RouteAbbreviation}}
             </ion-col>
             <ion-col aria-hidden="true" >


### PR DESCRIPTION
Rather than centering the text as suggested, reduce the size of the column containing the route number.

Closes #418.

Before:

![screenshot from 2018-02-08 18-17-27](https://user-images.githubusercontent.com/3988134/36003785-7d01124e-0cfd-11e8-896a-e60a237974d8.png)

After:

![screenshot from 2018-02-08 18-21-58](https://user-images.githubusercontent.com/3988134/36003795-8268a7ec-0cfd-11e8-8e19-aa1322129f90.png)

